### PR TITLE
feat: add Go project CI checklist and related skills section

### DIFF
--- a/README.md
+++ b/README.md
@@ -639,6 +639,29 @@ gh project create --title "Project Name"
 | `templates/auto-merge-direct.yml.template` | Auto-merge without branch protection |
 | `scripts/verify-github-project.sh` | Verification script for project setup |
 
+## Related Skills
+
+This skill focuses on GitHub platform configuration. For complete project setup:
+
+| Skill | Purpose |
+|-------|---------|
+| `go-development` | Go code patterns, Makefile interface, testing, linting |
+| `enterprise-readiness` | OpenSSF Scorecard, SLSA provenance, signed releases, CI workflow templates |
+| `git-workflow` | Git branching strategies, conventional commits |
+| `security-audit` | Deep security audits (OWASP, CVE analysis) |
+
+### Skill Coordination
+
+```
+github-project (this skill)
+├── Repository configuration
+├── Branch protection / rulesets
+├── Dependabot/Renovate auto-merge
+└── Coordinates with:
+    ├── go-development → CI workflow content (test, lint, build)
+    └── enterprise-readiness → Security workflows (Scorecard, CodeQL, SLSA)
+```
+
 ---
 
 **Made with ❤️ for Open Source by [Netresearch](https://www.netresearch.de/)**

--- a/SKILL.md
+++ b/SKILL.md
@@ -20,4 +20,28 @@ For workflows, CLI commands, templates, and troubleshooting guides, see `README.
 Key references:
 - `references/repository-structure.md` - Standard repo layout
 - `references/sub-issues.md` - Sub-issues GraphQL API
+- `references/dependency-management.md` - Dependabot/Renovate configuration
 - `templates/` - Auto-merge workflow templates
+
+## Go Project CI Checklist
+
+For Go projects, ensure these GitHub configurations:
+
+| Setting | Purpose | How |
+|---------|---------|-----|
+| Branch protection | Require tests pass before merge | Branch settings or Rulesets |
+| Dependabot/Renovate | Automated dependency updates | `.github/dependabot.yml` or `renovate.json` |
+| Auto-merge workflow | Merge minor/patch updates automatically | `templates/auto-merge*.yml` |
+| Required checks | CI workflow names in branch protection | Match exact workflow job names |
+
+For CI/CD workflow content (test, lint, build), see `go-development` skill.
+For security workflows (Scorecard, CodeQL, SLSA), see `enterprise-readiness` skill.
+
+## Related Skills
+
+| Skill | Purpose |
+|-------|---------|
+| `go-development` | Go code patterns, Makefile interface, testing, linting |
+| `enterprise-readiness` | OpenSSF Scorecard, SLSA provenance, signed releases |
+| `git-workflow` | Git branching strategies, conventional commits |
+| `security-audit` | Deep security audits (OWASP, CVE analysis) |


### PR DESCRIPTION
## Summary

- Add Go Project CI Checklist to SKILL.md with settings table
- Add Related Skills section to SKILL.md and README.md
- Add Skill Coordination diagram showing hub-and-spoke model
- Cross-reference go-development and enterprise-readiness skills

## Changes

### SKILL.md
- Added Go Project CI Checklist table with branch protection, Dependabot, auto-merge settings
- Added delegation pointers to go-development and enterprise-readiness skills
- Added Related Skills table

### README.md
- Added Related Skills section
- Added Skill Coordination diagram

## Skill Unification

This is part of a broader skill unification effort:

```
go-development (hub)
├── Code quality: linting, testing, fuzzing
├── Standard Makefile: test, build, lint, fuzz
└── Delegates to:
    ├── github-project (this skill) → repo setup, branch protection, auto-merge
    └── enterprise-readiness → supply chain security, SLSA, signing
```

## Test Plan

- [ ] Verify SKILL.md and README.md render correctly
- [ ] Verify cross-references to other skills are accurate