### PR TITLE
chore(ci): standardize release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,39 +15,59 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
         with:
           egress-policy: audit
 
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Get version from tag
         id: version
-        run: echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+        run: echo "version=${{GITHUB_REF#refs/tags/}}" >> $GITHUB_OUTPUT
 
-      - name: Create skill package
+      - name: Create github-project skill package
         run: |
-          mkdir -p dist
-          # Copy skill files from new structure
-          cp skills/github-project/SKILL.md dist/
-          cp LICENSE dist/
-          [ -d "skills/github-project/references" ] && cp -r skills/github-project/references dist/
-          [ -d "skills/github-project/scripts" ] && cp -r skills/github-project/scripts dist/
-          [ -d "skills/github-project/assets" ] && cp -r skills/github-project/assets dist/
-          [ -d "skills/github-project/templates" ] && cp -r skills/github-project/templates dist/
+          mkdir -p dist-skill
+          cp skills/github-project/SKILL.md dist-skill/
+          cp LICENSE dist-skill/
+          [ -d "skills/github-project/references" ] && cp -r skills/github-project/references dist-skill/
+          [ -d "skills/github-project/scripts" ] && cp -r skills/github-project/scripts dist-skill/
+          [ -d "skills/github-project/assets" ] && cp -r skills/github-project/assets dist-skill/
+          [ -d "skills/github-project/templates" ] && cp -r skills/github-project/templates dist-skill/
+          [ -d "skills/github-project/examples" ] && cp -r skills/github-project/examples dist-skill/
+          [ -f "skills/github-project/checkpoints.yaml" ] && cp skills/github-project/checkpoints.yaml dist-skill/
+          cd dist-skill
+          zip -r ../github-project-skill-${{ steps.version.outputs.version }}.zip .
+          tar -czvf ../github-project-skill-${{ steps.version.outputs.version }}.tar.gz .
+
+      - name: Create github-project plugin package
+        run: |
+          mkdir -p dist-plugin
+          # Include github-project skill files
+          mkdir -p dist-plugin/skills/github-project
+          cp skills/github-project/SKILL.md dist-plugin/skills/github-project/
+          [ -d "skills/github-project/references" ] && cp -r skills/github-project/references dist-plugin/skills/github-project/
+          [ -d "skills/github-project/scripts" ] && cp -r skills/github-project/scripts dist-plugin/skills/github-project/
+          [ -d "skills/github-project/assets" ] && cp -r skills/github-project/assets dist-plugin/skills/github-project/
+          [ -d "skills/github-project/templates" ] && cp -r skills/github-project/templates dist-plugin/skills/github-project/
+          [ -d "skills/github-project/examples" ] && cp -r skills/github-project/examples dist-plugin/skills/github-project/
+          [ -f "skills/github-project/checkpoints.yaml" ] && cp skills/github-project/checkpoints.yaml dist-plugin/skills/github-project/
+          cp LICENSE dist-plugin/
           # Include plugin manifest
-          [ -d ".claude-plugin" ] && cp -r .claude-plugin dist/
-          cd dist
-          zip -r ../github-project-${{ steps.version.outputs.version }}.zip .
-          tar -czvf ../github-project-${{ steps.version.outputs.version }}.tar.gz .
+          [ -d ".claude-plugin" ] && cp -r .claude-plugin dist-plugin/
+          cd dist-plugin
+          zip -r ../github-project-plugin-${{ steps.version.outputs.version }}.zip .
+          tar -czvf ../github-project-plugin-${{ steps.version.outputs.version }}.tar.gz .
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2.2.1
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
         with:
           files: |
-            github-project-${{ steps.version.outputs.version }}.zip
-            github-project-${{ steps.version.outputs.version }}.tar.gz
+            github-project-skill-${{ steps.version.outputs.version }}.zip
+            github-project-skill-${{ steps.version.outputs.version }}.tar.gz
+            github-project-plugin-${{ steps.version.outputs.version }}.zip
+            github-project-plugin-${{ steps.version.outputs.version }}.tar.gz
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Pin all GitHub Actions to SHA for supply chain security
- Add `step-security/harden-runner` (v2.14.2)
- Update `actions/checkout` to v6.0.2
- Update `softprops/action-gh-release` to v2.5.0
- Split into separate **skill** and **plugin** release packages
- Produce both `.zip` and `.tar.gz` formats

## Asset naming

| Package | Contents |
|---------|----------|
| `*-skill-v*.zip/.tar.gz` | Skill only (SKILL.md, references, scripts, templates) |
| `*-plugin-v*.zip/.tar.gz` | Full plugin (skill + .claude-plugin manifest, hooks, scripts) |

## Test plan

- [ ] Verify workflow YAML is valid
- [ ] Tag a release and confirm correct assets are produced