### PR TITLE
Fix auto-merge templates and add troubleshooting docs

### DIFF
--- a/skills/github-project/SKILL.md
+++ b/skills/github-project/SKILL.md
@@ -443,7 +443,11 @@ When dependency PRs aren't auto-merging, check these common issues:
 | Renovate PR not using bypass | Workflow racing with Renovate | Only approve in workflow; let Renovate enable auto-merge via `platformAutomerge` |
 | CI can't push to main | Branch protection blocks direct push | Use Renovate `lockFileMaintenance` instead |
 | Workflow not triggering | Rapid merges skip push events | Add `workflow_dispatch` trigger, run manually |
-| "Merge method X not allowed" | Wrong merge strategy | Check `required_linear_history`; use `--rebase` if true |
+| "Merge method X not allowed" | Wrong merge strategy | Check `gh api repos/O/R --jq '{merge: .allow_merge_commit, squash: .allow_squash_merge, rebase: .allow_rebase_merge}'`; match workflow |
+| Bot detection misses reruns | `github.actor` changes on synchronize | Use `github.event.pull_request.user.login` instead of `github.actor` |
+| Gitleaks fails on bot PRs | `GITLEAKS_LICENSE` secret unavailable | Skip gitleaks for bot PRs or use `.gitleaks.toml` allowlist |
+| Old PRs not auto-merging | Opened before workflow existed | Comment `@dependabot rebase` / `@renovate rebase` to trigger `synchronize` |
+| Can't merge workflow file PRs | `GITHUB_TOKEN` lacks `workflows` scope | Merge manually; use workflow check in `auto-merge-direct.yml` template |
 
 ### Branch Protection for Auto-merge
 

--- a/skills/github-project/assets/auto-merge-direct.yml.template
+++ b/skills/github-project/assets/auto-merge-direct.yml.template
@@ -3,6 +3,8 @@
 # Use this template when: Repository has no branch protection rules
 # Note: --auto flag requires branch protection; this template uses direct merge
 # Note: PRs that modify workflow files require manual merge (GITHUB_TOKEN limitation)
+# IMPORTANT: The merge method (--merge/--squash/--rebase) in the "Merge PR" step
+# MUST match the repository's allowed merge methods. Check Settings > General > Pull Requests.
 name: Auto-merge dependency PRs
 
 on:

--- a/skills/github-project/assets/auto-merge-queue.yml.template
+++ b/skills/github-project/assets/auto-merge-queue.yml.template
@@ -16,7 +16,11 @@ jobs:
   auto-merge:
     name: Auto-merge dependency PRs
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]' || github.actor == 'renovate[bot]'
+    # Use github.event.pull_request.user.login instead of github.actor
+    # because actor can change on synchronize/rerun events
+    if: >-
+      github.event.pull_request.user.login == 'dependabot[bot]' ||
+      github.event.pull_request.user.login == 'renovate[bot]'
 
     steps:
       - name: Harden Runner
@@ -26,7 +30,7 @@ jobs:
 
       - name: Dependabot metadata
         id: metadata
-        if: github.actor == 'dependabot[bot]'
+        if: github.event.pull_request.user.login == 'dependabot[bot]'
         uses: dependabot/fetch-metadata@v2
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/skills/github-project/assets/auto-merge.yml.template
+++ b/skills/github-project/assets/auto-merge.yml.template
@@ -1,5 +1,8 @@
 # .github/workflows/auto-merge.yml
 # Auto-merge dependency updates from Dependabot and Renovate
+# Requires: branch protection enabled (--auto flag needs it)
+# IMPORTANT: The merge method (--merge/--squash/--rebase) MUST match the
+# repository's allowed merge methods. Check Settings > General > Pull Requests.
 name: Auto-merge dependency updates
 
 on:
@@ -14,7 +17,11 @@ jobs:
   auto-merge:
     name: Auto-merge dependency PRs
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]' || github.actor == 'renovate[bot]'
+    # Use github.event.pull_request.user.login instead of github.actor
+    # because actor can change on synchronize/rerun events
+    if: >-
+      github.event.pull_request.user.login == 'dependabot[bot]' ||
+      github.event.pull_request.user.login == 'renovate[bot]'
 
     steps:
       - name: Harden Runner
@@ -24,7 +31,7 @@ jobs:
 
       - name: Dependabot metadata
         id: metadata
-        if: github.actor == 'dependabot[bot]'
+        if: github.event.pull_request.user.login == 'dependabot[bot]'
         uses: dependabot/fetch-metadata@v2
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
@@ -36,6 +43,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Enable auto-merge
+        # Change --squash to --merge or --rebase to match repo settings
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}

--- a/skills/github-project/references/dependency-management.md
+++ b/skills/github-project/references/dependency-management.md
@@ -373,7 +373,11 @@ permissions:
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]' || github.actor == 'renovate[bot]'
+    # Use github.event.pull_request.user.login (not github.actor)
+    # because actor can change on synchronize/rerun events
+    if: >-
+      github.event.pull_request.user.login == 'dependabot[bot]' ||
+      github.event.pull_request.user.login == 'renovate[bot]'
     steps:
       - name: Auto-approve PR
         run: gh pr review --approve "$PR_URL"
@@ -554,6 +558,93 @@ gh workflow run build.yml --repo OWNER/REPO --ref main
 **Impact:** `github-actions` may not have bypass permissions.
 
 **Solution:** For Renovate PRs, don't enable auto-merge in workflows. Let Renovate handle it via `platformAutomerge: true`.
+
+### Merge Method Mismatch in Auto-merge Workflow
+
+**Error:** `Merge method 'rebase' is not allowed on this repository` (or squash/merge)
+
+**Cause:** The auto-merge workflow uses `--rebase` but the repository only allows merge commits (or vice versa).
+
+**Diagnosis:**
+```bash
+# Check which merge methods are allowed
+gh api repos/OWNER/REPO --jq '{merge: .allow_merge_commit, squash: .allow_squash_merge, rebase: .allow_rebase_merge}'
+```
+
+**Solution:** Update the workflow's merge command to match:
+```yaml
+# Use the method that matches repo settings:
+run: gh pr merge --auto --merge "$PR_URL"   # if allow_merge_commit: true
+run: gh pr merge --auto --squash "$PR_URL"  # if allow_squash_merge: true
+run: gh pr merge --auto --rebase "$PR_URL"  # if allow_rebase_merge: true
+```
+
+### `github.actor` Unreliable for Bot Detection
+
+**Problem:** Auto-merge workflow uses `github.actor == 'dependabot[bot]'` but the workflow doesn't trigger on `synchronize` or `rerun` events.
+
+**Cause:** `github.actor` reflects who triggered the event, not who opened the PR. On `synchronize` events (new push) or manual reruns, the actor may change to the person who triggered the rerun.
+
+**Solution:** Always use `github.event.pull_request.user.login` instead:
+```yaml
+# ❌ Wrong - actor changes on synchronize/rerun
+if: github.actor == 'dependabot[bot]'
+
+# ✅ Correct - user.login is stable for the PR author
+if: github.event.pull_request.user.login == 'dependabot[bot]'
+```
+
+### Gitleaks Fails on Dependabot/Renovate PRs
+
+**Error:** `gitleaks-action` fails with license error on bot PRs.
+
+**Cause:** `gitleaks-action@v2` requires a `GITLEAKS_LICENSE` secret, but Dependabot runs with restricted secret access — it can only access secrets prefixed with `DEPENDABOT_`.
+
+**Solution:** Skip gitleaks on bot PRs or use the free mode:
+```yaml
+- name: Gitleaks
+  uses: gitleaks/gitleaks-action@v2
+  # Skip on bot PRs where GITLEAKS_LICENSE is unavailable
+  if: github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.user.login != 'renovate[bot]'
+  env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
+```
+
+Or add a `.gitleaks.toml` allowlist for known false positives.
+
+### Pre-existing PRs Don't Auto-merge
+
+**Problem:** PRs opened before the auto-merge workflow was added don't get auto-merged.
+
+**Cause:** The workflow triggers on `opened`, `synchronize`, and `reopened`. Pre-existing PRs already had their `opened` event.
+
+**Solution:** Either:
+1. Comment `@dependabot rebase` or `@renovate rebase` to trigger a `synchronize` event
+2. Close and reopen the PR to trigger `reopened`
+3. Manually merge the pre-existing PRs
+
+### GITHUB_TOKEN Cannot Modify Workflow Files
+
+**Problem:** Auto-merge fails for PRs that update `.github/workflows/` files.
+
+**Cause:** `GITHUB_TOKEN` (OAuth `gho_*` tokens) lack the `workflows` scope and cannot push or merge changes to workflow files. This is a GitHub security restriction.
+
+**Solution:** The `auto-merge-direct.yml` template includes a check for workflow file changes and skips auto-merge for those PRs, leaving a comment instead:
+```yaml
+- name: Check for workflow file changes
+  run: |
+    WORKFLOW_FILES=$(gh pr diff "$PR_URL" --name-only | grep -E '^\\.github/workflows/' || true)
+    if [ -n "$WORKFLOW_FILES" ]; then
+      echo "modifies_workflows=true" >> "$GITHUB_OUTPUT"
+    fi
+
+- name: Merge PR
+  if: steps.check-workflows.outputs.modifies_workflows != 'true'
+  run: gh pr merge --rebase "$PR_URL"
+```
+
+PRs modifying workflow files require manual merge by a repository admin.
 
 ## Comparison: Dependabot vs Renovate
 


### PR DESCRIPTION
## Summary

- Fix bot detection in all auto-merge workflow templates: use `github.event.pull_request.user.login` instead of `github.actor` (actor changes on synchronize/rerun events)
- Add merge method matching comments to all templates reminding users to match `--merge`/`--squash`/`--rebase` with repository settings
- Add 5 new troubleshooting items to `dependency-management.md` and quick reference in `SKILL.md`:
  - **Merge method mismatch**: workflow uses wrong `--merge`/`--squash`/`--rebase` flag
  - **`github.actor` unreliable**: changes on synchronize/rerun, use `user.login` instead
  - **Gitleaks fails on bot PRs**: `GITLEAKS_LICENSE` secret unavailable in Dependabot's restricted context
  - **Pre-existing PRs don't auto-merge**: opened before workflow existed, need rebase to trigger
  - **GITHUB_TOKEN can't modify workflow files**: PRs touching `.github/workflows/` require manual merge

## Context

These issues were discovered while fixing ~17 stuck dependency PRs across multiple Netresearch repositories. Each issue caused auto-merge workflows to silently fail or produce unexpected behavior.

## Test plan

- [ ] Verify templates render correctly when copied to `.github/workflows/`
- [ ] Verify troubleshooting section renders in skill reference
- [ ] Check merge queue template still works with GraphQL mutation