### PR TITLE
fix(refs): address Copilot review followups from #53/#54/#55

### DIFF
--- a/skills/github-project/references/auto-merge-guide.md
+++ b/skills/github-project/references/auto-merge-guide.md
@@ -102,7 +102,7 @@ for pr in "${prs[@]}"; do
   u=$(gh api graphql -f query="{
     repository(owner: \"$OWNER\", name: \"$NAME\") {
       pullRequest(number: $N) {
-        reviewThreads(first: 50) { nodes { isResolved } }
+        reviewThreads(first: 100) { nodes { isResolved } }
       }
     }
   }" | jq '[.data.repository.pullRequest.reviewThreads.nodes[]
@@ -113,9 +113,9 @@ done
 
 For each unresolved thread:
 
-1. Read the full comment body via `reviewThreads(first: 50) { nodes { id isResolved comments(first: 1) { nodes { author { login } body } } } }`.
+1. Read the initial comment body via `reviewThreads(first: 100) { nodes { id isResolved comments(first: 1) { nodes { author { login } body } } } }`. Bump `comments(first:)` or paginate if you need follow-up replies on the same thread rather than just the initiating comment.
 2. If valid → open a follow-up PR that addresses it, referencing the PR + thread by URL in the commit message.
-3. Reply on the thread using the GraphQL mutations in [`references/gh-cli-reference.md`](./gh-cli-reference.md): `addPullRequestReviewThreadReply` + `resolveReviewThread`.
+3. Reply on the thread using the GraphQL mutations in [`gh-cli-reference.md`](./gh-cli-reference.md): `addPullRequestReviewThreadReply` + `resolveReviewThread`.
 4. If not valid (false positive, design-intent) → reply with the reasoning (cite evidence — tested behavior, design docs, etc.) then resolve.
 
 **Don't silently dismiss review threads.** Even for false positives, leave a reply explaining why so the next person who opens the PR sees the decision.

--- a/skills/github-project/references/merge-strategy.md
+++ b/skills/github-project/references/merge-strategy.md
@@ -176,8 +176,9 @@ Neither branch protection nor rulesets support "block merge while any requested 
 If you need to hold merge until Copilot (or any other requested reviewer) has actually posted its review, the workaround is a custom GitHub Actions status check that queries pending reviewers and fails if any are outstanding — then require that check in branch protection.
 
 ```bash
-# Example: fail the check if any reviewer is still requested.
-pending=$(gh api "repos/$REPO/pulls/$PR" --jq '.requested_reviewers | length')
+# Example: fail the check if any reviewer — user or team — is still requested.
+pending=$(gh api "repos/$REPO/pulls/$PR" \
+  --jq '((.requested_reviewers // []) | length) + ((.requested_teams // []) | length)')
 if [[ "$pending" -gt 0 ]]; then
   echo "::error::Still waiting on $pending requested reviewer(s)"
   exit 1

--- a/skills/github-project/references/workflow-bash-patterns.md
+++ b/skills/github-project/references/workflow-bash-patterns.md
@@ -42,7 +42,7 @@ if [[ -z "$BUILD_TS" ]]; then
 fi
 ```
 
-Keep the empty-string check separately — `git show` can exit 0 and print nothing in edge cases (e.g. shallow clone with `fetch-depth=0` on a freshly-init'd repo).
+Keep the empty-string check separately — `git show` can exit 0 and print nothing in edge cases (e.g. shallow clone with `fetch-depth: 1` on a freshly-init'd repo; note that `fetch-depth: 0` in `actions/checkout` means full history, not shallow).
 
 ## Pipefail + early readers
 
@@ -55,7 +55,7 @@ set -euo pipefail
 find . -maxdepth 1 -name '*.go' -exec grep -l '^package main' {} \; -print | grep -q .
 ```
 
-When multiple files match, `find` keeps writing to the pipe while `grep -q .` exits on the first line. `find` gets SIGPIPE, the pipeline returns 141 under `pipefail`, the whole `if` evaluates as false — even though there ARE matching files.
+When multiple files match, `find` keeps writing to the pipe while `grep -q .` exits on the first line. `find` gets SIGPIPE, so the pipeline returns 141 under `pipefail` and the step fails — even though there ARE matching files. Wrapping the pipeline in `if pipeline; then …` has the same effect (the `if` branch evaluates as false).
 
 **Fix 1 — capture into a variable (no reader):**
 


### PR DESCRIPTION
Follow-up to Copilot review comments on the three recently-merged reference PRs:

## Changes

**`workflow-bash-patterns.md` (#53):**
- Clarify that `fetch-depth: 0` in `actions/checkout` means **full** history (not shallow); use `fetch-depth: 1` as the example of a shallow clone
- Rephrase the pipefail/SIGPIPE description — the example shows a pipeline, not an `if`, so the outcome is 'step fails' rather than 'if evaluates as false'

**`auto-merge-guide.md` (#54):**
- Bump `reviewThreads(first: 50 -> 100)` to GitHub's per-page maximum so the sweep doesn't silently miss threads on PRs with >50 threads
- Note that `comments(first: 1)` only returns the initiating comment (reply context needs higher `first:` or pagination)
- Fix link-text/href mismatch in the review-reply mutation pointer

**`merge-strategy.md` (#55):**
- Include `requested_teams` alongside `requested_reviewers` in the pending-review status check so team review requests are counted too

## Thread IDs resolved after merge

- #53: PRRT_kwDOQoDmGs58Zoh5, PRRT_kwDOQoDmGs58ZoiH
- #54: PRRT_kwDOQoDmGs58ZrK7, PRRT_kwDOQoDmGs58ZrLJ, PRRT_kwDOQoDmGs58ZrLW
- #55: PRRT_kwDOQoDmGs58Z7Uh