### PR TITLE
fix(refs): address Copilot second-sweep findings from #56

### DIFF
--- a/skills/github-project/references/auto-merge-guide.md
+++ b/skills/github-project/references/auto-merge-guide.md
@@ -111,6 +111,8 @@ for pr in "${prs[@]}"; do
 done
 ```
 
+`reviewThreads(first: 100)` covers GitHub's per-page maximum. Paginate with `pageInfo { hasNextPage endCursor }` + `after:` for PRs that might exceed 100 threads (long-running PRs on hot files).
+
 For each unresolved thread:
 
 1. Read the initial comment body via `reviewThreads(first: 100) { nodes { id isResolved comments(first: 1) { nodes { author { login } body } } } }`. Bump `comments(first:)` or paginate if you need follow-up replies on the same thread rather than just the initiating comment.

--- a/skills/github-project/references/merge-strategy.md
+++ b/skills/github-project/references/merge-strategy.md
@@ -180,7 +180,7 @@ If you need to hold merge until Copilot (or any other requested reviewer) has ac
 pending=$(gh api "repos/$REPO/pulls/$PR" \
   --jq '((.requested_reviewers // []) | length) + ((.requested_teams // []) | length)')
 if [[ "$pending" -gt 0 ]]; then
-  echo "::error::Still waiting on $pending requested reviewer(s)"
+  echo "::error::Still waiting on $pending review request(s) (user/team)"
   exit 1
 fi
 ```


### PR DESCRIPTION
Follow-up to Copilot comments on #56 (the follow-up to #55).

## Changes

**`merge-strategy.md`:** error message now says `review request(s) (user/team)` so the output matches the check's logic (it counts both users and teams).

**`auto-merge-guide.md`:** add a pagination note — `reviewThreads(first: 100)` is GitHub's per-page maximum; point at cursor pagination for PRs that might exceed it.

## Thread IDs resolved after merge

- PRRT_kwDOQoDmGs58lGOt
- PRRT_kwDOQoDmGs58lGPA