### PR TITLE
feat(refs): capture session retrospective learnings (Copilot cascade, GHA expressions, dependabot hygiene, template drift)

### DIFF
--- a/skills/github-project/references/auto-merge-guide.md
+++ b/skills/github-project/references/auto-merge-guide.md
@@ -124,6 +124,40 @@ For each unresolved thread:
 
 **Re-sweep after follow-up PRs merge.** Copilot often reviews the follow-up PR itself and posts new threads. The sweep isn't one-shot — run it again until the count hits zero across all touched PRs.
 
+### Wait for Copilot Before Merging (prevents the cascade)
+
+Copilot's review is **asynchronous**: it usually lands 1–3 min after the PR opens, sometimes longer on a busy day. If you enable `--auto --merge` the instant CI passes, you merge *before* Copilot has reviewed — and the review lands on an already-merged PR, which then needs a follow-up PR to address. Copilot reviews that follow-up too, so the same race repeats. A single round of non-trivial review can easily cascade to 5–6 follow-up PRs.
+
+**Prevention — poll for Copilot before enabling auto-merge:**
+
+```bash
+# Wait up to 5 min for Copilot's review to appear. If it never does
+# (skill-only docs PRs, repos without Copilot review enabled), the loop
+# exits on timeout and you proceed.
+for _ in $(seq 1 30); do
+  reviewed=$(gh pr view "$PR" --repo "$REPO" --json reviews --jq '
+    [.reviews[] | select(.author.login == "copilot-pull-request-reviewer")] | length')
+  [ "$reviewed" -ge 1 ] && break
+  sleep 10
+done
+
+# Now address any unresolved threads, THEN enable auto-merge.
+gh pr merge "$PR" --repo "$REPO" --auto --merge
+```
+
+**Or enforce via branch protection:** add `copilot-pull-request-reviewer` as a required reviewer so branch protection blocks merge until the review exists. GitHub's UI for this is under *Settings → Branches → Branch protection rules → Require review from Code Owners / specific reviewers*; for rulesets, set `required_pull_request_reviews.required_approving_review_count >= 1` with `dismiss_stale_reviews_on_push: true`. Note that *requested* isn't the same as *approved* — see [merge-strategy.md](./merge-strategy.md) on blocking on pending reviews.
+
+**If you still cascade**, expect it: budget 2–3 sweep rounds mentally rather than claiming "done" after the first merge. The Copilot-review → fix → merge → Copilot-reviews-the-fix loop is the norm on non-trivial text changes, not the exception.
+
+### Validate Copilot Suggestions Before Applying
+
+Copilot occasionally suggests syntactically invalid or semantically wrong code. Recent examples from this fleet:
+
+- **`?:` ternary** in a GitHub Actions expression — not supported; GHA expressions use `&&` / `||` chains
+- **`inputs.make_latest`** in a workflow that triggers on both `push.tags` and `workflow_dispatch` — the `inputs` context is undefined on `push` events and raises *"Unrecognized named-value: 'inputs'"*; use `github.event.inputs.*` for safety across events
+
+Treat suggestions as reviewer *input*, not ground truth. Read the code, verify against docs (see [workflow-bash-patterns.md](./workflow-bash-patterns.md) for the GHA expression specifics), and apply in the form that's actually correct. Reply with your adjusted reasoning on the thread rather than silently applying a broken suggestion and having to patch it two sweeps later.
+
 ## CI Annotations — Always Check Before Declaring a PR Clean
 
 CI checks can report `success` at the status-run level while still emitting **warning annotations** (typical for actionlint / shellcheck via reviewdog, CodeQL deprecation notices, YAML-lint). These annotations don't show up in `gh pr checks` or in the PR summary page — they only appear on the job's detail page or on the Files-Changed tab. Declaring a PR "clean" based on `gh pr checks` alone leaves real findings un-addressed.

--- a/skills/github-project/references/dependency-management.md
+++ b/skills/github-project/references/dependency-management.md
@@ -55,7 +55,7 @@ Dependabot's update job runs on the ecosystems configured, whether or not the ma
 
 ```bash
 # Latest Dependabot run conclusions
-gh api "repos/OWNER/REPO/actions/runs?event=dynamic&per_page=10" --jq '
+gh api "repos/OWNER/REPO/actions/runs?per_page=10" --jq '
   [.workflow_runs[] | select(.name == "Dependabot Updates" or .name == "Dependabot")
     | {conclusion, created_at, html_url}]'
 

--- a/skills/github-project/references/dependency-management.md
+++ b/skills/github-project/references/dependency-management.md
@@ -35,6 +35,37 @@ updates:
 | github-actions | GitHub Actions |
 | terraform | Terraform |
 
+### Ecosystem Hygiene — Only Declare What the Repo Actually Has
+
+Dependabot's update job runs on the ecosystems configured, whether or not the manifest files exist. Some ecosystems **hard-fail** when their manifest is missing; others silently no-op. Declaring ecosystems that don't apply turns main red on every scheduled Dependabot run, for no benefit:
+
+| Ecosystem | Missing manifest behavior |
+|-----------|---------------------------|
+| `npm` | **Hard error** — `dependency_file_not_found: /package.json not found` |
+| `devcontainers` | **Hard error** — `no devcontainers configs found` |
+| `docker` | Silent no-op (scans Dockerfile only if present) |
+| `gomod` | Silent no-op (scans go.mod only if present) |
+| `github-actions` | Silent no-op (scans workflows only if present) |
+| `pip` | **Hard error** — fails if no requirements*.txt / pyproject.toml |
+| `composer` | **Hard error** — fails if no composer.json |
+
+**Rule:** match the template's ecosystem set to the **class** of repo. A `go-lib` template shouldn't ship with `npm` and `devcontainers` entries because libraries don't have `package.json` or `.devcontainer/`. A `go-app` template can reasonably include `npm` because some Go apps ship frontend assets — but the first consumer without frontend assets will fail weekly until someone removes the entry or adds the manifest.
+
+**Diagnosing a weekly Dependabot failure on main:**
+
+```bash
+# Latest Dependabot run conclusions
+gh api "repos/OWNER/REPO/actions/runs?event=dynamic&per_page=10" --jq '
+  [.workflow_runs[] | select(.name == "Dependabot Updates" or .name == "Dependabot")
+    | {conclusion, created_at, html_url}]'
+
+# Open the failing run's log to find the specific ecosystem:
+gh run view <RUN_ID> --repo OWNER/REPO --log-failed |
+  grep -iE "dependency_file_not_found|no .* configs found" | head -5
+```
+
+If the failure comes from a template-derived ecosystem that doesn't apply: fix the template (so new consumers inherit the fix) *and* open a consumer-side PR to drop the ecosystem (so the existing repo stops failing). Running only one half leaves the drift check failing on the PR or the schedule failing on main. See [multi-repo-operations.md](./multi-repo-operations.md) for the template-consumer coordination pattern.
+
 ### Grouping Dependencies
 ```yaml
 updates:

--- a/skills/github-project/references/multi-repo-operations.md
+++ b/skills/github-project/references/multi-repo-operations.md
@@ -195,6 +195,35 @@ done
 
 This is the same worktree-authority rule as `git-workflow`, enforced inside the batch loop.
 
+## Template-Drift Resolution Pattern
+
+When a consumer repo's template-drift check fails and the fix is "remove a thing that doesn't apply here" (ecosystem, workflow, config entry), the drift is usually a **template bug**, not a consumer bug — the template was written too broad for the class of repo it's applied to.
+
+**Naive fix:** patch only the consumer. The drift check stays red forever because the template still declares the thing the consumer is missing. Adding an `intentional-drift:` exception works but accumulates per-repo carve-outs that future template authors don't see.
+
+**Correct fix:** patch the template AND the consumer in the same sweep. The template PR is the forward fix (next consumer inherits the correction); the consumer PR clears the current red.
+
+```
+1. Identify all consumers of the affected template path
+   gh search code --owner netresearch "templates/<template-name>" --limit 20
+
+2. Open the template-side PR first
+   - Remove the bad entry / tighten the template
+   - Reference the first observed consumer failure (URL of the red run)
+   - Flag that consumers will drift until synced; list them in the PR body
+
+3. Open the consumer-side PR(s) matching the template change
+   - Cross-reference: "Matches netresearch/.github#NN"
+   - Merge both in the same session so the drift window closes quickly
+
+4. Enable auto-merge on both. The consumer waits on its drift check,
+   which starts passing the moment the template PR lands.
+```
+
+**Rule of thumb for template scope:** the template should carry only what EVERY consumer of that class actually needs. A `go-lib` template with an `npm` dependabot entry is wrong because most Go libraries don't ship `package.json`. A `go-app` template with an `npm` entry is defensible — some go-apps DO ship frontend assets — but the class is loose enough that per-consumer overrides become common. When you see carve-outs accumulating in `intentional-drift:` lists, that's a signal the template is too broad for its consumer base and the classes should be split (e.g. `go-app` vs `go-app-headless`).
+
+See [dependency-management.md](./dependency-management.md) for which Dependabot ecosystems hard-fail when their manifest is missing (the common source of template drift on Go repos).
+
 ## Common Anti-Patterns
 
 | Anti-pattern | Consequence | Fix |

--- a/skills/github-project/references/workflow-bash-patterns.md
+++ b/skills/github-project/references/workflow-bash-patterns.md
@@ -160,6 +160,76 @@ Reusable workflows run under the **caller's** token. If the reusable job declare
 
 When reviewing PRs that touch caller workflows, the first thing to check is that the caller's `permissions:` is ≥ what every reusable workflow it calls declares.
 
+## Expression gotchas — release & multi-trigger workflows
+
+Workflows that accept both a "normal" trigger (e.g. `push: tags`) and a manual override (`workflow_dispatch` with inputs) repeatedly trip over the same expression-context quirks. Each cost us a round of Copilot back-and-forth in the release-process doc; bundling them here so the next reader finds them in one place.
+
+### `inputs.*` is not defined outside `workflow_dispatch` / `workflow_call`
+
+```yaml
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      tag: { required: true }
+
+jobs:
+  publish:
+    steps:
+      - uses: actions/checkout@...
+        with:
+          ref: ${{ inputs.tag || github.ref_name }}   # FAILS on push.tags
+```
+
+On `push.tags`, GitHub evaluates `inputs.tag` and raises *"Unrecognized named-value: 'inputs'"*. The workflow fails before any step runs.
+
+**Fix:** use `github.event.inputs.*`, which resolves to an empty string on non-dispatch events:
+
+```yaml
+          ref: ${{ github.event.inputs.tag || github.ref_name }}
+```
+
+### On `workflow_dispatch`, `github.ref_name` is the dispatch source, not a tag
+
+A workflow triggered via the Actions UI from `main` has `github.ref_name == 'main'`, even if the user supplied a tag via an input. Tag-source-of-truth workflows (release publishes, asset builds) must **explicitly** checkout the input tag, or they'll build assets from `main` HEAD and upload them to the tag's release:
+
+```yaml
+      - uses: actions/checkout@...
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref_name }}
+          fetch-tags: true
+```
+
+### GitHub Actions expressions have no ternary
+
+`a ? b : c` is a YAML-level syntax error — GHA expressions only support `&&` / `||`. The idiom is:
+
+```yaml
+# "if cond then A else B" -->  cond && A || B
+make_latest: ${{ github.event_name == 'workflow_dispatch' && 'false' || 'true' }}
+```
+
+Watch for the **truthy-string trap**: `'false'` is a non-empty string, so it's truthy. If you're branching on a boolean input, wrap it in `fromJSON()` to convert the string `'false'` to actual `false`:
+
+```yaml
+make_latest: ${{ fromJSON(github.event.inputs.make_latest || 'true') && 'true' || 'false' }}
+```
+
+Without `fromJSON`, `'false' && 'true' || 'false'` evaluates to `'true'` because the string `'false'` is truthy.
+
+### Hyphenated input names force bracket-expression access
+
+```yaml
+inputs:
+  make-latest: { type: boolean }   # hyphen
+
+# Must be referenced as:
+${{ inputs['make-latest'] }}       # not inputs.make-latest (parsed as subtraction!)
+```
+
+Prefer underscored names (`make_latest`) so dot-notation works. Matches GitHub's own action parameter style (`softprops/action-gh-release` uses `make_latest`, not `make-latest`).
+
 ## Related
 
 - [actionlint-guide.md](./actionlint-guide.md) — how to catch these at author-time


### PR DESCRIPTION
Retrospective additions from a multi-repo workflow-standardization session, bundled as four atomic commits — one per reference.

## 1. `auto-merge-guide.md` — Wait for Copilot before merging + validate suggestions

Learned from a 6-round Copilot review cascade this session: Copilot's review is **asynchronous** (1–3 min typical). Enabling `--auto --merge` the instant CI passes merges *before* Copilot reviews, and the review lands on an already-merged PR — requiring a follow-up that Copilot also reviews, cascading. Added two patterns:
- Poll for `copilot-pull-request-reviewer` in `.reviews[]` before enabling auto-merge
- Or enforce via branch protection (required reviewer)

Also: Copilot sometimes suggests syntactically invalid code (GHA ternary, `inputs.*` in multi-trigger workflows). Treat as input, not ground truth.

## 2. `workflow-bash-patterns.md` — GHA expression gotchas for multi-trigger workflows

Bundle four quirks that tripped up the release-process doc:
- `inputs.*` is undefined outside `workflow_dispatch` / `workflow_call` → use `github.event.inputs.*`
- `github.ref_name` on `workflow_dispatch` is the source ref, not a tag → explicit checkout with `ref:`
- No ternary; use `&&`/`||` chain + watch the truthy-string trap (wrap bool inputs in `fromJSON()`)
- Hyphenated input names force `inputs['hyphen-name']` access; prefer underscore

## 3. `dependency-management.md` — Dependabot ecosystem hygiene

Which ecosystems hard-fail vs silent no-op when their manifest is missing. Table of eight common ecosystems + rule: only declare what matches the CLASS of repo. Motivated by simple-ldap-go's weekly red on main from npm / devcontainers entries inherited from the go-lib template.

## 4. `multi-repo-operations.md` — Template-drift resolution pattern

When drift failure = consumer lacks something the template declares, patch **both sides** simultaneously rather than adding per-consumer `intentional-drift:` carve-outs. Include rule-of-thumb: accumulating carve-outs is a signal the template class is too broad and should be split.

## Links to the originating incidents

- Cascade: https://github.com/netresearch/github-release-skill/pull/4 → #6 → #7 → #8 → #9 → #10 → #11 (6 rounds)
- GHA expressions: thread trail on #7 / #8 / #9 / #10 / #11
- Dependabot: https://github.com/netresearch/simple-ldap-go/actions/runs/24687875276 (`dependency_file_not_found: /package.json`)
- Template drift: netresearch/.github#81 + netresearch/simple-ldap-go#159 (paired fix)