### PR TITLE
docs(auto-merge-guide): expand Copilot auto-approve race-condition guide

### DIFF
--- a/skills/github-project/SKILL.md
+++ b/skills/github-project/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: github-project
-description: "Use when PRs won't merge or show BLOCKED status, auto-merge fails for Dependabot/Renovate, branch protection or rulesets need configuring, GitHub Actions workflows have issues or CI is failing, setting up CODEOWNERS or PR templates, or diagnosing any GitHub repository configuration problem."
+description: "Use when PRs won't merge or show BLOCKED status (including green-CI + Copilot reviewer race conditions), auto-approve / auto-merge fails for Dependabot/Renovate, branch protection or rulesets need configuring, GitHub Actions workflows have issues or CI is failing, setting up CODEOWNERS or PR templates, or diagnosing any GitHub repository configuration problem."
 license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires gh CLI, git."
 metadata:
@@ -81,7 +81,7 @@ gh api graphql -f query='query($owner:String!,$repo:String!,$pr:Int!){
 
 ### Merge Strategy Issues
 
-Rebase merge fails with signed commits: enable squash or auto-detect strategy. Workflow file PRs need manual merge (GITHUB_TOKEN lacks `workflows` scope). Copilot reviewer race conditions: re-run auto-approve workflow. See `references/auto-merge-guide.md`.
+Rebase merge fails with signed commits: enable squash or auto-detect strategy. Workflow file PRs need manual merge (GITHUB_TOKEN lacks `workflows` scope). Copilot reviewer race conditions (PR `BLOCKED` despite green CI + empty `reviewDecision`): re-run auto-approve workflow; long-term fix is adding `pull_request_review` trigger. See `references/auto-merge-guide.md` → "Auto-Approve Race Condition with Copilot Reviewer" (canonical).
 
 ## Running Scripts
 

--- a/skills/github-project/SKILL.md
+++ b/skills/github-project/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: github-project
-description: "Use when PRs won't merge or show BLOCKED status (including green-CI + Copilot reviewer race conditions), auto-approve / auto-merge fails for Dependabot/Renovate, branch protection or rulesets need configuring, GitHub Actions workflows have issues or CI is failing, setting up CODEOWNERS or PR templates, or diagnosing any GitHub repository configuration problem."
+description: "Use when PRs won't merge or show BLOCKED status (including green-CI Copilot-review race conditions), auto-approve / auto-merge fails for Dependabot/Renovate, branch protection or rulesets need configuring, GitHub Actions workflows have issues or CI is failing, or setting up CODEOWNERS / PR templates."
 license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires gh CLI, git."
 metadata:
@@ -81,7 +81,7 @@ gh api graphql -f query='query($owner:String!,$repo:String!,$pr:Int!){
 
 ### Merge Strategy Issues
 
-Rebase merge fails with signed commits: enable squash or auto-detect strategy. Workflow file PRs need manual merge (GITHUB_TOKEN lacks `workflows` scope). Copilot reviewer race conditions (PR `BLOCKED` despite green CI + empty `reviewDecision`): re-run auto-approve workflow; long-term fix is adding `pull_request_review` trigger. See `references/auto-merge-guide.md` → "Auto-Approve Race Condition with Copilot Reviewer" (canonical).
+See `references/auto-merge-guide.md` for: rebase-merge-with-signed-commits fixes, workflow-file PR manual merges, and the Copilot-review auto-approve race (PR `BLOCKED` despite green CI + empty `reviewDecision`).
 
 ## Running Scripts
 

--- a/skills/github-project/checkpoints.yaml
+++ b/skills/github-project/checkpoints.yaml
@@ -178,7 +178,7 @@ mechanical:
       # with Copilot Reviewer".
       WF=.github/workflows/pr-quality.yml
       test -f "$WF" || exit 0   # not applicable if workflow doesn't exist
-      grep -qE '^\s*pull_request_review\s*:' "$WF"
+      grep -qE '^[[:space:]]*pull_request_review[[:space:]]*:' "$WF"
     severity: warning
     desc: >-
       pr-quality.yml should also trigger on pull_request_review to avoid the

--- a/skills/github-project/checkpoints.yaml
+++ b/skills/github-project/checkpoints.yaml
@@ -167,6 +167,24 @@ mechanical:
     severity: info
     desc: "Auto-merge should dynamically detect merge strategy from repo settings"
 
+  # === AUTO-APPROVE (pr-quality.yml) COPILOT RACE CONDITION ===
+  - id: GH-33
+    type: command
+    target: |
+      # If pr-quality.yml exists, verify it triggers on pull_request_review as
+      # well as pull_request_target. Without pull_request_review, the approval
+      # job races with Copilot and leaves PRs BLOCKED with empty reviewDecision.
+      # See references/auto-merge-guide.md → "Auto-Approve Race Condition
+      # with Copilot Reviewer".
+      WF=.github/workflows/pr-quality.yml
+      test -f "$WF" || exit 0   # not applicable if workflow doesn't exist
+      grep -qE '^\s*pull_request_review\s*:' "$WF"
+    severity: warning
+    desc: >-
+      pr-quality.yml should also trigger on pull_request_review to avoid the
+      Copilot auto-approve race condition (PR stuck BLOCKED with empty
+      reviewDecision)
+
   # === BRANCH PROTECTION AUDIT ===
   - id: GH-30
     type: command

--- a/skills/github-project/references/auto-merge-guide.md
+++ b/skills/github-project/references/auto-merge-guide.md
@@ -50,30 +50,94 @@ EOF
 | Gitleaks fails on bot PRs | `GITLEAKS_LICENSE` secret unavailable | Skip gitleaks for bot PRs or use `.gitleaks.toml` allowlist |
 | Old PRs not auto-merging | Opened before workflow existed | Comment `@dependabot rebase` / `@renovate rebase` to trigger `synchronize` |
 | Can't merge workflow file PRs | `GITHUB_TOKEN` lacks `workflows` scope | Merge manually; use workflow check in `auto-merge-direct.yml` template |
-| Auto-approve skipped, PR stuck `REVIEW_REQUIRED` | Auto-approve raced with Copilot reviewer | Re-run the auto-approve workflow after Copilot finishes (see below) |
+| Auto-approve skipped, PR stuck `REVIEW_REQUIRED` or blank `reviewDecision` | Auto-approve raced with Copilot reviewer | Re-run the auto-approve workflow after Copilot finishes; long-term fix is adding `pull_request_review` trigger — see [Auto-Approve Race Condition with Copilot Reviewer](#auto-approve-race-condition-with-copilot-reviewer) |
 
 ## Auto-Approve Race Condition with Copilot Reviewer
 
-When using a solo-maintainer auto-approve workflow alongside GitHub Copilot as a reviewer, a race condition can leave PRs stuck in `REVIEW_REQUIRED`:
+**This section is the canonical home for the "PR stuck BLOCKED despite green CI + explicit approval" gotcha.** Project-level `CLAUDE.md` entries should cross-reference this file rather than restating the details.
 
-1. New push triggers both auto-approve workflow and Copilot review
-2. Auto-approve runs first, sees Copilot as a pending reviewer, skips approval
-3. Stale review dismissal clears any previous approvals from the push
-4. Copilot finishes reviewing (state: `COMMENTED`) but doesn't approve
-5. No approval exists, PR is `BLOCKED`
+When using a solo-maintainer auto-approve workflow alongside GitHub Copilot as a reviewer, a race condition can leave PRs stuck blocked even though every gate appears satisfied:
 
-**Symptoms:** `mergeStateStatus: BLOCKED`, `reviewDecision: REVIEW_REQUIRED`, auto-approve step shows "skipped", `reviewRequests` is empty.
+1. New push triggers both the auto-approve workflow and Copilot review
+2. Auto-approve runs first, sees Copilot as a pending reviewer, skips approval silently
+3. Stale review dismissal (`dismiss_stale_reviews_on_push: true`) clears any previous approvals from the push
+4. Copilot finishes reviewing with state `COMMENTED` (not `APPROVED`) — Copilot almost never actively approves
+5. No approval exists anywhere; PR stays `BLOCKED`
 
-**Fix:** Re-run the auto-approve workflow after Copilot finishes:
+**Symptoms** — `gh pr view N --json mergeStateStatus,reviewDecision` returns one of:
+
+- `{"mergeStateStatus":"BLOCKED", "reviewDecision":"REVIEW_REQUIRED"}` (classic case)
+- `{"mergeStateStatus":"BLOCKED", "reviewDecision":""}` (no review decision computed yet — seen when Copilot is mid-review and the repo has `required_approving_review_count >= 1`)
+
+In both cases: all CI status checks are `SUCCESS`, there are no `CHANGES_REQUESTED` reviews, no unresolved review threads, and the auto-approve job reports `success` in `gh run list`. The approval simply never happened.
+
+### Diagnosis
+
+Confirm the silent-skip is the cause before re-running anything:
 
 ```bash
-# Find the workflow run ID
+# 1. Find the latest auto-approve run and its job id
+RUN_ID=$(gh api "repos/OWNER/REPO/actions/runs?per_page=10" \
+  --jq '.workflow_runs[] | select(.name == "PR Quality Gates") | .id' | head -1)
+JOB_ID=$(gh api "repos/OWNER/REPO/actions/runs/$RUN_ID/jobs" \
+  --jq '.jobs[] | select(.name | test("Auto-[Aa]pprove")) | .id')
+
+# 2. Inspect the job log for the skip marker
+gh api "repos/OWNER/REPO/actions/jobs/$JOB_ID/logs" \
+  | grep -iE "skip|copilot|pending reviewer|requested_reviewers"
+```
+
+If the log contains a line like "Skipping approval: pending reviewers" or shows `requested_reviewers` containing `copilot-pull-request-reviewer[bot]`, the race condition is confirmed.
+
+Also useful — current reviewer state:
+
+```bash
+gh api repos/OWNER/REPO/pulls/PR_NUMBER \
+  --jq '{requested_reviewers: [.requested_reviewers[]?.login], requested_teams: [.requested_teams[]?.slug]}'
+```
+
+An empty `requested_reviewers` after Copilot's review has landed confirms Copilot is no longer blocking — so a rerun will now succeed.
+
+### Fix — re-run the workflow
+
+```bash
+# Find the most recent PR Quality Gates run for this PR's head commit
 gh api "repos/OWNER/REPO/actions/runs?per_page=5" \
-  --jq '.workflow_runs[] | select(.name == "YOUR_WORKFLOW_NAME") | {id, head_sha: .head_sha[:7]}'
+  --jq '.workflow_runs[] | select(.name == "PR Quality Gates") | {id, head_sha: .head_sha[:7]}'
 
 # Re-run it
 gh api repos/OWNER/REPO/actions/runs/RUN_ID/rerun -X POST
 ```
+
+Wait ~2 minutes, then re-check `gh pr view N --json mergeStateStatus,reviewDecision`. Expected result: `{"mergeStateStatus":"CLEAN", "reviewDecision":"APPROVED"}`.
+
+> **Why the rerun works:** `gh run rerun` on the latest run re-reads the current reviewer list. By that point Copilot has submitted its review, so it's no longer in `requested_reviewers` and auto-approve proceeds. See also [CI Re-runs Replay the Same Commit](#ci-re-runs-replay-the-same-commit) — use the LATEST run id (not an older failed one) so the rerun executes against current HEAD.
+
+### Prevention
+
+Pick one of these patterns when authoring or updating a `pr-quality.yml` / auto-approve workflow. See [`../assets/pr-quality.yml.template`](../assets/pr-quality.yml.template) for the baseline.
+
+**Option A — also trigger on review submission (simplest):**
+
+```yaml
+on:
+    pull_request_target:
+        types: [opened, synchronize, reopened]
+    pull_request_review:
+        types: [submitted, dismissed]
+```
+
+When Copilot submits its review, the workflow re-fires and now sees an empty `requested_reviewers` list. This is the lowest-effort fix and works for most solo-maintainer setups.
+
+**Option B — poll with retry inside the approval step (race-free, slower):**
+
+Before approving, poll `requested_reviewers` until it's empty or a timeout elapses. Typical timeout: 5 minutes. Use this when Copilot reviews are slow or when missed-approval events are expensive (e.g. repos with tight merge SLOs).
+
+**Option C — wait for Copilot explicitly:**
+
+Gate the approval step on `github.event.review.user.login == 'copilot-pull-request-reviewer[bot]' && github.event.review.state != 'changes_requested'` in a `pull_request_review`-triggered job. Race-free but fires only after Copilot posts — not useful when Copilot isn't actually assigned to the PR.
+
+**Do NOT** "fix" this by dropping `required_approving_review_count` to `0` — that loses the OpenSSF Scorecard Code-Review point and removes the audit trail that shows a deliberate approval happened.
 
 ## Post-Merge Review Sweep
 

--- a/skills/github-project/references/auto-merge-guide.md
+++ b/skills/github-project/references/auto-merge-guide.md
@@ -76,14 +76,17 @@ In both cases: all CI status checks are `SUCCESS`, there are no `CHANGES_REQUEST
 Confirm the silent-skip is the cause before re-running anything:
 
 ```bash
-# 1. Find the latest auto-approve run and its job id
-RUN_ID=$(gh api "repos/OWNER/REPO/actions/runs?per_page=10" \
-  --jq '.workflow_runs[] | select(.name == "PR Quality Gates") | .id' | head -1)
+# 1. Find the latest auto-approve run for THIS PR's head commit and its job id.
+#    Scoping by head_sha prevents picking up runs from other PRs/branches.
+HEAD_SHA=$(gh pr view PR_NUMBER --repo OWNER/REPO --json headRefOid --jq .headRefOid)
+RUN_ID=$(gh api "repos/OWNER/REPO/actions/runs?head_sha=$HEAD_SHA&per_page=20" \
+  --jq '[.workflow_runs[] | select(.name == "PR Quality Gates")] | .[0].id')
 JOB_ID=$(gh api "repos/OWNER/REPO/actions/runs/$RUN_ID/jobs" \
-  --jq '.jobs[] | select(.name | test("Auto-[Aa]pprove")) | .id')
+  --jq '.jobs[] | select(.name | test("Auto-[Aa]pprove")) | .id' | head -1)
 
-# 2. Inspect the job log for the skip marker
-gh api "repos/OWNER/REPO/actions/jobs/$JOB_ID/logs" \
+# 2. Inspect the job log for the skip marker. Use `gh run view --log` — the
+#    raw /logs API returns a zip archive that won't grep cleanly.
+gh run view --log --job="$JOB_ID" --repo OWNER/REPO \
   | grep -iE "skip|copilot|pending reviewer|requested_reviewers"
 ```
 
@@ -101,12 +104,14 @@ An empty `requested_reviewers` after Copilot's review has landed confirms Copilo
 ### Fix — re-run the workflow
 
 ```bash
-# Find the most recent PR Quality Gates run for this PR's head commit
-gh api "repos/OWNER/REPO/actions/runs?per_page=5" \
-  --jq '.workflow_runs[] | select(.name == "PR Quality Gates") | {id, head_sha: .head_sha[:7]}'
+# Scope the lookup to THIS PR's head commit — filtering only by workflow name
+# can return runs from other PRs/branches.
+HEAD_SHA=$(gh pr view PR_NUMBER --repo OWNER/REPO --json headRefOid --jq .headRefOid)
+RUN_ID=$(gh api "repos/OWNER/REPO/actions/runs?head_sha=$HEAD_SHA&per_page=20" \
+  --jq '[.workflow_runs[] | select(.name == "PR Quality Gates")] | .[0].id')
 
 # Re-run it
-gh api repos/OWNER/REPO/actions/runs/RUN_ID/rerun -X POST
+gh api repos/OWNER/REPO/actions/runs/$RUN_ID/rerun -X POST
 ```
 
 Wait ~2 minutes, then re-check `gh pr view N --json mergeStateStatus,reviewDecision`. Expected result: `{"mergeStateStatus":"CLEAN", "reviewDecision":"APPROVED"}`.


### PR DESCRIPTION
## Summary

Expands the existing **Auto-Approve Race Condition with Copilot Reviewer** section in `references/auto-merge-guide.md` so it covers the full diagnose-fix-prevent cycle instead of just the re-run workaround. Marks it as the canonical home for this gotcha so project-level `CLAUDE.md` entries can link here instead of duplicating the details.

## Why

A concrete session hit this on [netresearch/t3x-nr-vault#116](https://github.com/netresearch/t3x-nr-vault/pull/116):

- All 43 CI status checks `SUCCESS`
- `pr-quality / Auto-Approve (Solo Maintainer)` job reported success
- `github-actions[bot]` had approved the PR (from a previous push)
- No unresolved review threads, no `CHANGES_REQUESTED`
- Still `mergeStateStatus: BLOCKED`, `reviewDecision: ""` (empty string — not `REVIEW_REQUIRED`)

The skill covered the re-run fix but didn't mention:

1. The empty-`reviewDecision` symptom variant (distinct from `REVIEW_REQUIRED`)
2. How to diagnose the silent-skip from job logs
3. Prevention patterns (workflow-config fixes, not just remediation)

So the user's project-level `CLAUDE.md` carried the full write-up (`Auto-Approve Race Condition with Copilot Reviewer`) — per the learned-rule "Skills are team memory", that content belongs here.

## Changes

- **`references/auto-merge-guide.md`** — expand the race-condition section:
  - Second symptom variant: `reviewDecision: ""`
  - Diagnosis block (extract job id, grep log for skip marker, check current `requested_reviewers`)
  - Prevention options A/B/C (`pull_request_review` trigger / poll-with-retry / gate on `pull_request_review`)
  - Anti-pattern warning against setting `required_approving_review_count: 0`
  - Cross-link to `CI Re-runs Replay the Same Commit` so people don't rerun the old failed run
  - Updated troubleshooting table row to cover both symptom variants
- **`SKILL.md`** — surface "Copilot reviewer race conditions" in the frontmatter `description` and update the Merge Strategy Issues quick line to point at the canonical section
- **`checkpoints.yaml`** — new `GH-33` (severity `warning`): detects `pr-quality.yml` that lacks a `pull_request_review` trigger. No-ops when the workflow doesn't exist. Follows the existing `GH-24..GH-27` pattern of command/regex checks against workflow files.

## Test plan

- [x] `yamllint skills/github-project/checkpoints.yaml` clean
- [x] Markdown structure preserved — all cross-references resolve (`#ci-re-runs-replay-the-same-commit`, `../assets/pr-quality.yml.template`, `#auto-approve-race-condition-with-copilot-reviewer`)
- [x] Commit signed (GPG) and `Signed-off-by:` matches author (`sebastian.mendel@netresearch.de`)
- [ ] CI (actionlint, markdownlint, etc.) passes on push