### PR TITLE
fix(checkpoints): GH-24..27 accept reusable-workflow delegation

### DIFF
--- a/skills/github-project/checkpoints.yaml
+++ b/skills/github-project/checkpoints.yaml
@@ -139,33 +139,42 @@ mechanical:
     severity: warning
     desc: "Auto-merge workflow should exist for Dependabot/Renovate PRs"
 
+  # Auto-merge workflows can either:
+  #   (a) delegate to the netresearch org reusable workflow
+  #       (netresearch/.github/.github/workflows/auto-merge-deps.yml), which
+  #       encapsulates the trigger, bot-gating, --auto merging, and dynamic
+  #       merge-strategy detection; or
+  #   (b) inline the full implementation with pull_request_target: + the
+  #       same bot-gating and --auto patterns.
+  # GH-24..27 accept either path.
+
   - id: GH-24
     type: regex
     target: .github/workflows/auto-merge-deps.yml
-    pattern: 'on:\s*\n\s*pull_request_target:'
+    pattern: 'uses:\s*netresearch/\.github/\.github/workflows/auto-merge-deps\.yml|on:\s*\n\s*pull_request_target:'
     severity: error
-    desc: "Auto-merge workflow must use pull_request_target trigger (not pull_request) for bot PR write permissions"
+    desc: "Auto-merge workflow must delegate to netresearch reusable workflow OR use pull_request_target trigger for bot PR write permissions"
 
   - id: GH-25
     type: regex
     target: .github/workflows/auto-merge-deps.yml
-    pattern: 'github\.event\.pull_request\.user\.login'
+    pattern: 'uses:\s*netresearch/\.github/\.github/workflows/auto-merge-deps\.yml|github\.event\.pull_request\.user\.login'
     severity: warning
-    desc: "Auto-merge should check github.event.pull_request.user.login (not github.actor which changes on reruns)"
+    desc: "Auto-merge should delegate to reusable workflow OR check github.event.pull_request.user.login (not github.actor which changes on reruns)"
 
   - id: GH-26
     type: regex
     target: .github/workflows/auto-merge-deps.yml
-    pattern: '--auto'
+    pattern: 'uses:\s*netresearch/\.github/\.github/workflows/auto-merge-deps\.yml|--auto'
     severity: warning
-    desc: "Auto-merge should use gh pr merge --auto (not direct merge) to respect branch protection and merge queues"
+    desc: "Auto-merge should delegate to reusable workflow OR use gh pr merge --auto to respect branch protection and merge queues"
 
   - id: GH-27
     type: regex
     target: .github/workflows/auto-merge-deps.yml
-    pattern: 'gh api.*repos/\$'
+    pattern: 'uses:\s*netresearch/\.github/\.github/workflows/auto-merge-deps\.yml|gh api.*repos/\$'
     severity: info
-    desc: "Auto-merge should dynamically detect merge strategy from repo settings"
+    desc: "Auto-merge should delegate to reusable workflow OR dynamically detect merge strategy from repo settings"
 
   # === AUTO-APPROVE (pr-quality.yml) COPILOT RACE CONDITION ===
   - id: GH-33

--- a/skills/github-project/checkpoints.yaml
+++ b/skills/github-project/checkpoints.yaml
@@ -152,31 +152,34 @@ mechanical:
   # uses: 'foo', uses: "foo"). Glob target accepts either auto-merge-deps.yml
   # or auto-merge.yml (GH-23 already treats both as valid filenames).
 
+  # The netresearch reusable-workflow path is unique enough to match without
+  # caring about uses:-line quoting (uses: foo, uses: 'foo', uses: "foo" all
+  # contain the netresearch/... substring identically).
   - id: GH-24
     type: regex
     target: .github/workflows/auto-merge*.yml
-    pattern: 'uses:[[:space:]]*["'\'']?netresearch/\.github/\.github/workflows/auto-merge-deps\.yml|on:[[:space:]]*\n[[:space:]]*pull_request_target:'
+    pattern: 'netresearch/\.github/\.github/workflows/auto-merge-deps\.yml|on:[[:space:]]*\n[[:space:]]*pull_request_target:'
     severity: error
     desc: "Auto-merge workflow must delegate to netresearch reusable workflow OR use pull_request_target trigger for bot PR write permissions"
 
   - id: GH-25
     type: regex
     target: .github/workflows/auto-merge*.yml
-    pattern: 'uses:[[:space:]]*["'\'']?netresearch/\.github/\.github/workflows/auto-merge-deps\.yml|github\.event\.pull_request\.user\.login'
+    pattern: 'netresearch/\.github/\.github/workflows/auto-merge-deps\.yml|github\.event\.pull_request\.user\.login'
     severity: warning
     desc: "Auto-merge should delegate to reusable workflow OR check github.event.pull_request.user.login (not github.actor which changes on reruns)"
 
   - id: GH-26
     type: regex
     target: .github/workflows/auto-merge*.yml
-    pattern: 'uses:[[:space:]]*["'\'']?netresearch/\.github/\.github/workflows/auto-merge-deps\.yml|--auto'
+    pattern: 'netresearch/\.github/\.github/workflows/auto-merge-deps\.yml|--auto'
     severity: warning
     desc: "Auto-merge should delegate to reusable workflow OR use gh pr merge --auto to respect branch protection and merge queues"
 
   - id: GH-27
     type: regex
     target: .github/workflows/auto-merge*.yml
-    pattern: 'uses:[[:space:]]*["'\'']?netresearch/\.github/\.github/workflows/auto-merge-deps\.yml|gh api.*repos/\$'
+    pattern: 'netresearch/\.github/\.github/workflows/auto-merge-deps\.yml|gh api.*repos/\$'
     severity: info
     desc: "Auto-merge should delegate to reusable workflow OR dynamically detect merge strategy from repo settings"
 

--- a/skills/github-project/checkpoints.yaml
+++ b/skills/github-project/checkpoints.yaml
@@ -148,31 +148,35 @@ mechanical:
   #       same bot-gating and --auto patterns.
   # GH-24..27 accept either path.
 
+  # Patterns allow optional quoting after `uses:` (YAML accepts uses: foo,
+  # uses: 'foo', uses: "foo"). Glob target accepts either auto-merge-deps.yml
+  # or auto-merge.yml (GH-23 already treats both as valid filenames).
+
   - id: GH-24
     type: regex
-    target: .github/workflows/auto-merge-deps.yml
-    pattern: 'uses:\s*netresearch/\.github/\.github/workflows/auto-merge-deps\.yml|on:\s*\n\s*pull_request_target:'
+    target: .github/workflows/auto-merge*.yml
+    pattern: 'uses:[[:space:]]*["'\'']?netresearch/\.github/\.github/workflows/auto-merge-deps\.yml|on:[[:space:]]*\n[[:space:]]*pull_request_target:'
     severity: error
     desc: "Auto-merge workflow must delegate to netresearch reusable workflow OR use pull_request_target trigger for bot PR write permissions"
 
   - id: GH-25
     type: regex
-    target: .github/workflows/auto-merge-deps.yml
-    pattern: 'uses:\s*netresearch/\.github/\.github/workflows/auto-merge-deps\.yml|github\.event\.pull_request\.user\.login'
+    target: .github/workflows/auto-merge*.yml
+    pattern: 'uses:[[:space:]]*["'\'']?netresearch/\.github/\.github/workflows/auto-merge-deps\.yml|github\.event\.pull_request\.user\.login'
     severity: warning
     desc: "Auto-merge should delegate to reusable workflow OR check github.event.pull_request.user.login (not github.actor which changes on reruns)"
 
   - id: GH-26
     type: regex
-    target: .github/workflows/auto-merge-deps.yml
-    pattern: 'uses:\s*netresearch/\.github/\.github/workflows/auto-merge-deps\.yml|--auto'
+    target: .github/workflows/auto-merge*.yml
+    pattern: 'uses:[[:space:]]*["'\'']?netresearch/\.github/\.github/workflows/auto-merge-deps\.yml|--auto'
     severity: warning
     desc: "Auto-merge should delegate to reusable workflow OR use gh pr merge --auto to respect branch protection and merge queues"
 
   - id: GH-27
     type: regex
-    target: .github/workflows/auto-merge-deps.yml
-    pattern: 'uses:\s*netresearch/\.github/\.github/workflows/auto-merge-deps\.yml|gh api.*repos/\$'
+    target: .github/workflows/auto-merge*.yml
+    pattern: 'uses:[[:space:]]*["'\'']?netresearch/\.github/\.github/workflows/auto-merge-deps\.yml|gh api.*repos/\$'
     severity: info
     desc: "Auto-merge should delegate to reusable workflow OR dynamically detect merge strategy from repo settings"
 


### PR DESCRIPTION
## Summary

Many netresearch repos now delegate auto-merge to the org reusable workflow:

\`\`\`yaml
jobs:
  auto-merge:
    uses: netresearch/.github/.github/workflows/auto-merge-deps.yml@main
\`\`\`

The reusable workflow itself handles trigger, bot-gating, \`--auto\` merging, and dynamic merge-strategy detection. So the previous checkpoints (which required inline implementations in the **caller** file) flagged these modern, correct setups as errors.

## Change

All four checkpoints (GH-24, GH-25, GH-26, GH-27) now accept either:
- (a) delegation to the netresearch reusable workflow, **or**
- (b) the original inline implementation with \`pull_request_target:\` + bot-gating + \`--auto\`

Regex alternation keeps the check mechanical.

Also corrected GH-24's description: \`pull_request:\` is the correct trigger when delegating via \`uses:\` (the reusable workflow declares both \`pull_request:\` and \`workflow_call:\` on purpose). The old description implied \`pull_request_target:\` was always required — not the case for the reusable pattern.

## Verification

Against netresearch/t3x-nr-llm (thin caller), all four previously-error checkpoints now pass with evidence \`Pattern found in .github/workflows/auto-merge-deps.yml\`.

## Test plan

- [ ] CI green
- [x] Manual: re-ran assessment against t3x-nr-llm (thin-caller pattern) — all four pass