### PR TITLE
docs: document npm as a distribution channel

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -26,9 +26,12 @@ skills/github-project/
 ## Distribution Channels
 
 - **Composer**: `netresearch/github-project-skill` via `composer.json` (requires `composer-agent-skill-plugin`)
+- **npm**: `github:netresearch/github-project-skill` via `package.json` (requires `@netresearch/agent-skill-coordinator`, which discovers the skill in `node_modules` and registers it in `AGENTS.md` via a `postinstall` hook)
 - **Claude Code plugin**: `.claude-plugin/plugin.json` for marketplace distribution
 - **npx / skills.sh**: Direct install via `npx skills add`
 - **Git clone / release download**: Manual installation
+
+When making changes to release or distribution logic, all five channels must be considered. The npm channel ships from a `package.json` allowlist (`files: ["skills/github-project/", LICENSE files, README.md]`) — anything outside that allowlist is invisible to npm consumers.
 
 ## Key Design Decisions
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -31,7 +31,7 @@ skills/github-project/
 - **npx / skills.sh**: Direct install via `npx skills add`
 - **Git clone / release download**: Manual installation
 
-When making changes to release or distribution logic, all five channels must be considered. The npm channel ships from a `package.json` allowlist (`files: ["skills/github-project/", LICENSE files, README.md]`) — anything outside that allowlist is invisible to npm consumers.
+When making changes to release or distribution logic, all five channels must be considered. The npm channel ships from a `package.json` allowlist (`files: ["skills/github-project/", "LICENSE-MIT", "LICENSE-CC-BY-SA-4.0", "README.md"]`) — anything outside that allowlist is invisible to npm consumers.
 
 ## Key Design Decisions
 

--- a/skills/github-project/references/multi-repo-operations.md
+++ b/skills/github-project/references/multi-repo-operations.md
@@ -103,8 +103,8 @@ The canonical order is: **version-bump PR merged → tag pushed**, never the rev
 
 Before touching any repo, validate:
 
-- `plugin.json.version` / `composer.json.version` parity against each other
-- For repos that also ship via npm: `package.json.version` is either the placeholder `0.0.0-source` (publish-time-rewritten by the Release workflow) **or** matches the others (release marker, e.g. `@netresearch/agent-skill-coordinator`). Mixing the two within one repo is the bug pattern to look for.
+- `plugin.json.version` is present (authoritative) and `composer.json` has **no** `version` field (Packagist derives the version from git tags); if `SKILL.md` frontmatter carries a `metadata.version`, it must match `plugin.json.version`
+- For repos that also ship via npm: `package.json.version` is either the placeholder `0.0.0-source` (publish-time-rewritten by the Release workflow) **or** matches `plugin.json` (for coordinator-style packages, e.g. `@netresearch/agent-skill-coordinator`). Mixing the two within one repo is the bug pattern to look for.
 - Current git tag on default branch is not already the target version
 - CI on default branch is green
 - No pending version-bump PR already open

--- a/skills/github-project/references/multi-repo-operations.md
+++ b/skills/github-project/references/multi-repo-operations.md
@@ -103,7 +103,8 @@ The canonical order is: **version-bump PR merged → tag pushed**, never the rev
 
 Before touching any repo, validate:
 
-- `plugin.json.version` / `composer.json.version` / `package.json.version` parity against each other
+- `plugin.json.version` / `composer.json.version` parity against each other
+- For repos that also ship via npm: `package.json.version` is either the placeholder `0.0.0-source` (publish-time-rewritten by the Release workflow) **or** matches the others (release marker, e.g. `@netresearch/agent-skill-coordinator`). Mixing the two within one repo is the bug pattern to look for.
 - Current git tag on default branch is not already the target version
 - CI on default branch is green
 - No pending version-bump PR already open
@@ -116,7 +117,7 @@ skills/skill-repo/scripts/check-version-parity.sh            # parity only
 skills/skill-repo/scripts/check-version-parity.sh v1.2.4     # also require tag parity
 ```
 
-That script handles the Netresearch conventions (`plugin.json` has the authoritative version, `composer.json` must not have one, `SKILL.md` `metadata.version` in frontmatter matches `plugin.json`). Don't copy the snippet below inline — it was a sketch for illustration; the real script handles empty-arg mode, missing files, glob-empty iteration, and the quoted-or-unquoted frontmatter form. Call the shipped script.
+That script handles the Netresearch conventions (`plugin.json` has the authoritative version, `composer.json` must not have one, `SKILL.md` `metadata.version` in frontmatter matches `plugin.json`, and `package.json.version` is either `0.0.0-source` for git-installed skill packages or matches `plugin.json` for npm-published coordinator-style packages). Don't copy the snippet below inline — it was a sketch for illustration; the real script handles empty-arg mode, missing files, glob-empty iteration, and the quoted-or-unquoted frontmatter form. Call the shipped script.
 
 ```bash
 # Illustrative only — for non-skill repos, adapt the shape but handle empties


### PR DESCRIPTION
## Summary

Two follow-up doc edits addressing review threads on #67 that were not fixed in the merged code:

- **`docs/ARCHITECTURE.md`**: add npm to the Distribution Channels section. Previously listed only Composer, Claude Code plugin, npx/skills.sh, and manual installs — future maintainers wouldn't see npm as a packaging surface to consider.
- **`skills/github-project/references/multi-repo-operations.md`**: clarify the version-parity rule. The pre-merge guidance said `plugin.json.version` / `composer.json.version` / `package.json.version` must all match — but skill packages intentionally ship `0.0.0-source` in `package.json` (publish-time rewritten), so blanket parity would flag the merged shape as broken.

## Addresses

- copilot-pull-request-reviewer thread on `package.json:3` (PRRT_kwDOQoDmGs5_GzUj)
- copilot-pull-request-reviewer thread on `README.md:137` (PRRT_kwDOQoDmGs5_GzUo)

## Test plan

- [x] Doc renders correctly (Markdown only, no code/CI impact)
- [ ] Confirm Lint check passes on this PR