### PR TITLE
docs(github-project): verify a PR actually merged through the queue

### DIFF
--- a/skills/github-project/references/auto-merge-guide.md
+++ b/skills/github-project/references/auto-merge-guide.md
@@ -345,9 +345,11 @@ To find that CI and confirm the PR lands:
 
 ```bash
 # Is it queued, and at what position?
-gh api graphql -f query='{ repository(owner:"OWNER",name:"REPO"){
-  mergeQueue { entries(first:10){ nodes{ position state pullRequest{ number } } } } } }' \
-  --jq '.data.repository.mergeQueue.entries.nodes[]?'
+gh api graphql -f query='query($owner:String!,$repo:String!){
+  repository(owner:$owner,name:$repo){
+    mergeQueue { entries(first:10){ nodes{ position state pullRequest{ number } } } } } }' \
+  -f owner=OWNER -f repo=REPO \
+  --jq '.data.repository.mergeQueue?.entries?.nodes[]? // empty'
 
 # Watch the queue's own CI (note the merge_group event, not pull_request)
 gh run list --repo OWNER/REPO --event merge_group --limit 5 \
@@ -356,7 +358,7 @@ gh run list --repo OWNER/REPO --event merge_group --limit 5 \
 
 # Confirm it actually merged (state MERGED + branch gone)
 gh pr view <N> --repo OWNER/REPO --json state,mergedAt,mergeCommit \
-  --jq '{state, mergedAt, mergeCommit: (.mergeCommit.oid // "none")}'
+  --jq '{state, mergedAt, mergeCommit: (.mergeCommit?.oid // "none")}'
 ```
 
 Poll `state == "MERGED"` (or a `merge_group` run concluding `failure`) before declaring

--- a/skills/github-project/references/auto-merge-guide.md
+++ b/skills/github-project/references/auto-merge-guide.md
@@ -333,6 +333,36 @@ When landing multiple dependent PRs, expect the dependent PRs to need rebasing a
 | `REVIEW_REQUIRED` after rebase | Stale review dismissal cleared approval | Re-run auto-approve workflow |
 | Unresolved threads block merge | Old threads survive rebase | Resolve via GraphQL `resolveReviewThread` |
 
+### Verifying a PR Actually Merged (enqueue ≠ merged)
+
+On a merge-queue repo, `gh pr merge … --merge` (or `--auto`) only **enqueues** the PR —
+the command returns success immediately and the PR is **still open**. Don't report
+"merged" off the exit code; the queue runs its own CI first and merges later (minutes,
+if the queue runs the full matrix). It can also silently stall.
+
+The queue runs CI on a synthetic branch named `gh-readonly-queue/<base>/pr-<N>-<sha>`.
+To find that CI and confirm the PR lands:
+
+```bash
+# Is it queued, and at what position?
+gh api graphql -f query='{ repository(owner:"OWNER",name:"REPO"){
+  mergeQueue { entries(first:10){ nodes{ position state pullRequest{ number } } } } } }' \
+  --jq '.data.repository.mergeQueue.entries.nodes[]?'
+
+# Watch the queue's own CI (note the merge_group event, not pull_request)
+gh run list --repo OWNER/REPO --event merge_group --limit 5 \
+  --json status,conclusion,headBranch,name \
+  --jq '.[] | select(.headBranch|test("pr-<N>-")) | "\(.status)/\(.conclusion // "-") \(.name)"'
+
+# Confirm it actually merged (state MERGED + branch gone)
+gh pr view <N> --repo OWNER/REPO --json state,mergedAt,mergeCommit \
+  --jq '{state, mergedAt, mergeCommit: (.mergeCommit.oid // "none")}'
+```
+
+Poll `state == "MERGED"` (or a `merge_group` run concluding `failure`) before declaring
+done — green checks on the PR head are necessary but not sufficient once a queue is in
+play.
+
 ## Signed Commits and Merge Strategy Compatibility
 
 GitHub can only auto-sign **merge commits** and **squash merges**. It **cannot** auto-sign rebased commits. If branch protection requires signed commits and the workflow uses `--rebase`, merges fail with:


### PR DESCRIPTION
Small addition to `references/auto-merge-guide.md`, complementing the existing Merge Queue Behavior section.

On a merge-queue repo, `gh pr merge --merge`/`--auto` only **enqueues** — the command returns success immediately, the PR stays open, and the queue merges later (or stalls). Reporting "merged" off the exit code is wrong.

Adds a **"Verifying a PR Actually Merged (enqueue ≠ merged)"** subsection: the `gh-readonly-queue/<base>/pr-<N>-<sha>` CI branch naming, and the recipe to confirm landing — GraphQL `mergeQueue.entries` for position/state, `gh run list --event merge_group` to watch the queue CI, and `gh pr view --json state,mergedAt` to confirm `MERGED` before declaring done.

Distilled from merging a real PR through a queue where the full-matrix CI ran ~9.5 min on the readonly-queue branch after enqueue.