### PR TITLE
chore(release): v2.15.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "github-project",
-  "version": "2.15.1",
+  "version": "2.15.2",
   "description": "GitHub repository setup, branch protection, and configuration",
   "repository": "https://github.com/netresearch/github-project-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",

--- a/skills/github-project/SKILL.md
+++ b/skills/github-project/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires gh CLI, git."
 metadata:
   author: Netresearch DTT GmbH
-  version: "2.15.1"
+  version: "2.15.2"
   repository: https://github.com/netresearch/github-project-skill
 allowed-tools: Bash(gh:*) Bash(git:*) Bash(grep:*) Read Write
 ---


### PR DESCRIPTION
Release v2.15.2.

Bumps plugin.json + skill metadata version 2.15.1 → 2.15.2.

Content since v2.15.1:
- docs(repo-setup): SonarCloud whole-file re-attribution on wholesale refactors (#88)
- ci: adopt canonical skill template (#87)