### PR TITLE
ci: re-sync labeler.yml with skill template (clears drift)

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -6,7 +6,15 @@ ci:
       - any-glob-to-any-file: ['.github/**/*', 'Makefile']
 dependencies:
   - changed-files:
-      - any-glob-to-any-file: ['composer.json', 'composer.lock', 'package.json', 'package-lock.json', 'bun.lock', 'bun.lockb', 'yarn.lock', '.devcontainer/**/*']
+      - any-glob-to-any-file:
+          - 'composer.json'
+          - 'composer.lock'
+          - 'package.json'
+          - 'package-lock.json'
+          - 'bun.lock'
+          - 'bun.lockb'
+          - 'yarn.lock'
+          - '.devcontainer/**/*'
 skill:
   - changed-files:
       - any-glob-to-any-file: ['skills/**/*', '.claude-plugin/**/*', 'plugin.json']


### PR DESCRIPTION
The netresearch/.github skill template reformatted `.github/labeler.yml` (multi-line `dependencies` glob list). This repo carried the older inline form, so Template Drift failed on main. Re-syncs byte-identical with the template to clear the drift — same fix already applied to security-audit-skill and jira-skill.