### PR TITLE
Add GHCR package management to gh-CLI reference

### DIFF
--- a/skills/github-project/references/gh-cli-reference.md
+++ b/skills/github-project/references/gh-cli-reference.md
@@ -143,13 +143,13 @@ gh api "orgs/ORG/packages/container/PACKAGE"
 # Delete a package — needs BOTH read:packages AND delete:packages.
 # admin:org alone is NOT enough; delete:packages alone still 403s.
 gh auth refresh -h github.com -s read:packages,delete:packages
-gh api --method DELETE "orgs/ORG/packages/container/PACKAGE"   # 204; GET then 404
+gh api -X DELETE "orgs/ORG/packages/container/PACKAGE"   # 204; GET then 404
 ```
 
 Verify the token's effective scopes from GitHub's response header, not `gh auth status` (which can lag):
 
 ```bash
-gh api "orgs/ORG/packages/container/PACKAGE" --include 2>&1 | grep -i '^X-Oauth-Scopes:'
+gh api "" --include 2>&1 | grep -i '^X-Oauth-Scopes:'
 ```
 
 ## Files and Content

--- a/skills/github-project/references/gh-cli-reference.md
+++ b/skills/github-project/references/gh-cli-reference.md
@@ -131,6 +131,27 @@ gh release view --repo OWNER/REPO
 gh release download TAG --repo OWNER/REPO
 ```
 
+## Packages (GHCR)
+
+```bash
+# List org container packages
+gh api "orgs/ORG/packages?package_type=container"
+
+# Inspect a package (needs read:packages)
+gh api "orgs/ORG/packages/container/PACKAGE"
+
+# Delete a package — needs BOTH read:packages AND delete:packages.
+# admin:org alone is NOT enough; delete:packages alone still 403s.
+gh auth refresh -h github.com -s read:packages,delete:packages
+gh api --method DELETE "orgs/ORG/packages/container/PACKAGE"   # 204; GET then 404
+```
+
+Verify the token's effective scopes from GitHub's response header, not `gh auth status` (which can lag):
+
+```bash
+gh api "orgs/ORG/packages/container/PACKAGE" --include 2>&1 | grep -i '^X-Oauth-Scopes:'
+```
+
 ## Files and Content
 
 ```bash


### PR DESCRIPTION
## Why

When deleting a GHCR org container package via the API, the required token scopes are not obvious: `admin:org` alone is *not* sufficient, and `delete:packages` on its own still 403s. The deletion needs **both** `read:packages` and `delete:packages`. `gh auth status` can also lag behind the token's actual scopes, making the failure confusing to diagnose.

## What

Adds a new **Packages (GHCR)** section to `skills/github-project/references/gh-cli-reference.md`, placed right after "Releases and Tags". It covers:

- Listing org container packages
- Inspecting a package (`read:packages`)
- Deleting a package and the exact scope combination required (`read:packages` + `delete:packages`)
- Verifying effective token scopes from the `X-OAuth-Scopes` response header rather than `gh auth status`

Reference file only — `SKILL.md` is untouched to stay under its word cap.