### PR TITLE
Add field-tested PR/CI/merge-gate gotchas

### DIFF
--- a/skills/github-project/references/gh-cli-reference.md
+++ b/skills/github-project/references/gh-cli-reference.md
@@ -42,6 +42,9 @@ gh pr merge NUMBER --repo OWNER/REPO --auto --merge
 # Merge PR directly
 gh pr merge NUMBER --repo OWNER/REPO --merge  # or --squash, --rebase
 
+# Wait for PR CI to finish — use the native watcher, NOT a hand-rolled poll loop
+gh pr checks NUMBER --repo OWNER/REPO --watch --fail-fast
+
 # Comment on PR
 gh pr comment NUMBER --repo OWNER/REPO --body "message"
 
@@ -103,8 +106,11 @@ gh run view RUN_ID --repo OWNER/REPO
 # View failed logs
 gh run view RUN_ID --repo OWNER/REPO --log-failed
 
-# Re-run failed jobs
+# Re-run failed jobs (genuine flakes only — see caveat below)
 gh run rerun RUN_ID --repo OWNER/REPO --failed
+
+# Wait for a workflow run to finish (native watcher, prefer over hand-rolled loops)
+gh run watch RUN_ID --repo OWNER/REPO
 
 # Manually trigger workflow
 gh workflow run WORKFLOW.yml --repo OWNER/REPO --ref main
@@ -179,6 +185,41 @@ gh repo edit OWNER/REPO --description "New description"
 ```
 
 ## Common Troubleshooting Patterns
+
+### Wait for CI with the native watcher, not a hand-rolled loop
+
+To wait for PR checks, run `gh pr checks NUMBER --repo OWNER/REPO --watch [--fail-fast]` (or `gh run watch RUN_ID` for a specific run) as a background command — do **not** hand-write a `jq` poll loop. The native watcher already handles pending-state representation, new-check appearance, and refresh; hand-rolled loops re-derive those semantics from undocumented field shapes (`conclusion` may be `""`, `null`, or absent while a check is running) and reliably get them wrong.
+
+Three recurring bugs in ad-hoc watchers:
+
+- An empty-string `conclusion` not matched by the "pending" filter → false "all checks done".
+- A bare `pending -eq 0 && break` snapshot, which is true both **before** runs register and **after** they finish. Run immediately after a push (or a close/reopen), it reads "0 pending" before the freshly-triggered run has appeared → false "all green" → premature merge.
+- A wrong `createdAt` cutoff that skips the actual run → false timeout.
+
+`gh pr checks` exits non-zero when checks fail — gate on the exit code. If you must hand-roll (watching something `gh` has no watcher for), gate on a **named required check reaching a terminal pass/fail state**, never on a 0-pending count. After pushing, capture the new SHA and confirm `headRefOid` matches before trusting any watch.
+
+### `gh run rerun` re-runs the OLD state — only for genuine flakes
+
+`gh run rerun [--failed]` reuses the original `GITHUB_SHA`/`GITHUB_REF` recorded at run-creation time. Two consequences:
+
+- For `pull_request` workflows that SHA is the **merge commit** computed when the run was first created, so a rerun still tests the PR against the **old base**. After fixing a base-branch breakage, a rerun reproduces the old failure. To pick up new base state, create a new event: rebase the PR branch onto the fixed base and push (an empty commit works). (Reusable-workflow `@ref` resolution is also pinned at run-creation — see `reusable-workflow-pitfalls.md`.)
+- Reruns are correct only for genuinely transient infra failures where the same code state should pass: runner/network blips, partial codecov uploads, registry pull flakes (e.g. `Get "https://registry-1.docker.io/v2/": context deadline exceeded`), Sigstore/Rekor 409s. Don't debug the workflow for those — just `gh run rerun --failed`.
+
+### Rapid `gh api` calls intermittently return HTTP 401
+
+Rapid sequences of `gh api` calls (REST + GraphQL) sometimes return `401 "Requires authentication"` even with valid auth — transient, clears with ~5-10s spacing and a retry. **Trap:** piping a `gh` listing straight into `while read` consumes the 401 error text as data when a call fails (e.g. JSON error braces get fed into a GraphQL mutation as "thread IDs"). Always capture output into a variable first, check the exit status, then iterate; add a `sleep 5-10` between bulk review-thread replies/resolves.
+
+### Add an image to an issue or PR (no browser needed)
+
+GitHub's native attachment uploader (`user-attachments/assets/…`) needs a browser session + CSRF and cannot be driven by `gh`/the API — but that does **not** mean images are impossible. Commit the PNGs to a dedicated branch (in a fork if you lack push to the target), then embed the raw URL in the body/comment:
+
+```bash
+git push fork HEAD:issue-NNNN-screenshots
+# In the issue/PR body:
+# ![before](https://raw.githubusercontent.com/USER/REPO/BRANCH/before.png)
+```
+
+`raw.githubusercontent.com` serves `image/png` and GitHub renders it inline via camo. Generate the image first; for a JS-populated widget, point the page at a local copy of the real data and screenshot the rendered result.
 
 ### Debug Auto-merge Pipeline
 

--- a/skills/github-project/references/merge-strategy.md
+++ b/skills/github-project/references/merge-strategy.md
@@ -134,6 +134,64 @@ Both are marked as "Verified" in the GitHub UI:
 
 ## Troubleshooting
 
+### Diagnose `mergeStateStatus: BLOCKED` before naming a cause
+
+When a PR is `BLOCKED`, **do not assert a cause** (and never reflexively say "blocked on review" / "waiting for a reviewer") until you have fetched the effective ruleset and named the exact gating rule. `mergeStateStatus` alone does not tell you why; a human-approval gate is almost never the reason. The PR page states the reason in plain text ("All comments must be resolved", "Required statuses must pass") — read it, and the same facts are queryable.
+
+The single most common cause is **unresolved review threads** (including from bots) — check that first:
+
+```bash
+# reviewThreads is ONLY available via GraphQL — it is NOT a valid `gh pr view --json` field
+gh api graphql -f query='{repository(owner:"O",name:"R"){pullRequest(number:N){
+  reviewThreads(first:50){nodes{id isResolved}}}}}' \
+  --jq '[.data.repository.pullRequest.reviewThreads.nodes[]|select(.isResolved==false)]|length'
+```
+
+Passing `reviewThreads` to `gh pr view --json` errors "Unknown JSON field" — a merge-gate script that does this silently fails open and allows every merge. If the unresolved count is >0, address each comment, reply citing the fix commit, resolve. Only if it is 0 do you inspect the ruleset:
+
+```bash
+gh api repos/{owner}/{repo}/rules/branches/{BASE} --jq 'group_by(.type)[]|{type:.[0].type,n:length}'
+gh pr view N --json reviewDecision,mergeStateStatus,statusCheckRollup
+```
+
+Then name the specific rule (`copilot_code_review`, `required_status_checks`, `non_fast_forward`, merge queue, …). A `pull_request` rule with `reviewDecision: ""` means there is **no human-approval requirement at all**.
+
+### Never merge while a review is announced or in flight
+
+Once a reviewer is requested or has *started* (by you, a ruleset, or automation), its pendency blocks the merge until it resolves — regardless of `mergeStateStatus`. `CLEAN` is necessary but never sufficient: a `copilot_code_review` ruleset with `review_on_push: false` reports `CLEAN` off an *earlier* commit's review while a new one is still running, and a reviewer that has *started* drops off the request list without submitting — so `reviewRequests: []` is **not** "all clear". Check the timeline / pending-review state, not just `reviewRequests`. Do not request or re-request a reviewer as a pre-merge step (announcing one commits you to waiting). The absence of a review is not itself a blocker — you cannot require a review to *exist* (bots fail, decline, or are unconfigured) — but an *announced* one must be allowed to finish.
+
+### `gh pr merge` falsely reports "base branch policy prohibits the merge"
+
+`gh pr merge` (GraphQL path) can fail with "the base branch policy prohibits the merge" even when every requirement is verifiably satisfied (rollup SUCCESS, signature valid, 0 required approvals, 0 unresolved threads, branch up to date, no blocking rulesets), and `--auto` never fires either. The REST endpoint succeeds immediately on the same head SHA:
+
+```bash
+gh api -X PUT repos/{owner}/{repo}/pulls/{n}/merge -f merge_method=merge
+```
+
+Use this **only after the merge gate is genuinely verified** — the REST path bypasses whatever GraphQL mis-evaluated, so it must not be used to force past a *real* policy block.
+
+### All merge methods rejected — merge-method ruleset deadlock
+
+When every `gh pr merge --merge/--rebase/--squash` (and REST `PUT .../merge`) returns `"<method> merges are not allowed on this repository"` (HTTP 405) even though `gh api repos/<r> --jq '{allow_merge_commit,allow_squash_merge,allow_rebase_merge}'` shows a method enabled, the cause is a deadlock: an **org-level ruleset** sets `pull_request.allowed_merge_methods`, and the effective allowed set is the **intersection** of that with the repo's `allow_*_merge` flags. If the org allows only `squash` but the repo has `allow_squash_merge: false`, the intersection is empty and nothing merges.
+
+Diagnosis gotcha: `repos/<r>/rules/branches/main` may show a *permissive* list because `orgs/<org>/rulesets` is not listable without org-admin, so the stricter org ruleset is invisible and the contradiction looks like a GitHub bug — it isn't. `--admin` does **not** bypass `allowed_merge_methods` (it only bypasses status checks / required reviews). The only fixes are repo/org-admin actions (enable the org-required method at the repo level, exempt the repo, or adjust the org ruleset). Do not toggle repo merge settings autonomously on an inference — flag it for the owner.
+
+### Copilot-review ruleset blocked by Copilot's own quota
+
+Some repos gate merges on a `copilot_code_review` **ruleset** (visible via `gh api repos/$R/rules/branches/main`, not classic branch protection) that requires a fresh Copilot review on the head commit. When Copilot is quota-limited org-wide it posts a `COMMENTED` review saying it "was unable to review … reached their quota limit" — which does **not** satisfy the ruleset, so `gh pr merge` returns "add `--auto` or `--admin`" and `mergeStateStatus` stays `BLOCKED`. Re-requesting just reproduces the quota message.
+
+When all real checks pass (CodeQL, actionlint, SonarCloud, DCO, …) and only the quota-stuck Copilot gate blocks, admin-merge:
+
+```bash
+gh pr merge $PR --repo $R --merge --admin
+```
+
+Only for the unfulfillable-Copilot case — never admin-merge to skip a *failing* real check.
+
+### SonarCloud PR gate re-attributes pre-existing issues to a refactor
+
+SonarCloud measures "new code" as lines touched by the PR, so mechanical refactors (e.g. method extraction, literal→const swaps) re-attribute pre-existing duplication and uncovered lines to the PR, failing `new_duplicated_lines_density` or `codecov/patch`. Don't resort to test-theater or risky out-of-scope de-duplication inside a behavior-preserving PR. First fix what is genuinely cheap and meaningful (a small unit test for an extracted helper often flips `codecov/project` green). For the structural residue, confirm the gate is **non-required** (`mergeStateStatus: UNSTABLE`, not `BLOCKED`), write a "Quality gate note" section into the PR body naming the metric, the cause, and why it is out of scope, then merge. Style-rule whack-a-mole (each push surfacing the next batch) is best handled by modernizing the whole file in one pass — but verify bulk codemods with the language's own parser (a naive `var`→`const` regex turns `var x;` into invalid `const x;`).
+
 ### "Merge commits are not allowed on this repository"
 
 **Cause:** `allow_merge_commit` is false in repository settings.

--- a/skills/github-project/references/merge-strategy.md
+++ b/skills/github-project/references/merge-strategy.md
@@ -142,9 +142,10 @@ The single most common cause is **unresolved review threads** (including from bo
 
 ```bash
 # reviewThreads is ONLY available via GraphQL — it is NOT a valid `gh pr view --json` field
-gh api graphql -f query='{repository(owner:"O",name:"R"){pullRequest(number:N){
-  reviewThreads(first:50){nodes{id isResolved}}}}}' \
-  --jq '[.data.repository.pullRequest.reviewThreads.nodes[]|select(.isResolved==false)]|length'
+gh api graphql -f query='query($owner:String!,$repo:String!,$pr:Int!){
+  repository(owner:$owner,name:$repo){pullRequest(number:$pr){
+    reviewThreads(first:50){nodes{id isResolved}}}}}' -f owner=O -f repo=R -F pr=N \
+  --jq '[.data.repository.pullRequest?.reviewThreads?.nodes[]?|select(.isResolved==false)]|length'
 ```
 
 Passing `reviewThreads` to `gh pr view --json` errors "Unknown JSON field" — a merge-gate script that does this silently fails open and allows every merge. If the unresolved count is >0, address each comment, reply citing the fix commit, resolve. Only if it is 0 do you inspect the ruleset:

--- a/skills/github-project/references/pr-commit-cleanup.md
+++ b/skills/github-project/references/pr-commit-cleanup.md
@@ -30,3 +30,17 @@ If close/reopen doesn't work:
 1. **Create a new PR:** Push the same branch and create a fresh PR
 2. **Rebase onto upstream:** `git rebase upstream/main && git push --force-with-lease`
 3. **Update fork first:** Sync fork's main before creating the feature branch
+
+## Never reset a PR's head branch to its base commit
+
+Force-updating an open PR's head ref so it momentarily points at the base branch's commit (zero diff vs. base) causes GitHub to **auto-close the PR**. Reopening then fails ("Could not open the pull request") and you must open a fresh PR.
+
+This bites when replacing a PR's commits (e.g. to re-sign unsigned ones): patching the branch ref back to base before re-committing produces the zero-diff state. Instead, build the replacement commits on top of base **locally** and force-push in one step, so the branch always has ≥1 commit ahead of base:
+
+```bash
+git reset --soft origin/main   # keep the working tree; do NOT push this state
+git commit -s -m "…"           # rebuild the commit(s)
+git push --force-with-lease    # branch is never momentarily zero-diff on the remote
+```
+
+If a PR does get auto-closed this way, just open a new PR from the (now-correct) branch rather than fighting reopen.

--- a/skills/github-project/references/reusable-workflow-pitfalls.md
+++ b/skills/github-project/references/reusable-workflow-pitfalls.md
@@ -111,5 +111,5 @@ A run with `conclusion: startup_failure` (or `failure`), **zero jobs**, and a di
 2. **Permission mismatch** — the caller's job omits an explicit `permissions:` block, the repo's `default_workflow_permissions` is `read`, but a nested reusable job requests e.g. `security-events: write`. UI error: "The nested job 'X' is requesting 'security-events: write', but is only allowed 'security-events: none'." Deceptive because a **byte-identical** workflow file passes in sibling repos whose repo-default permissions are permissive — it is repo-environmental, not a file diff. Fix at the caller per pitfall #4: grant the calling job exactly the scopes the reusable declares.
 
 ```bash
-gh api repos/O/R/actions/permissions --jq .default_workflow_permissions   # reveals a restrictive 'read' default
+gh api repos/O/R/actions/permissions --jq '.default_workflow_permissions? // ""'   # reveals a restrictive 'read' default
 ```

--- a/skills/github-project/references/reusable-workflow-pitfalls.md
+++ b/skills/github-project/references/reusable-workflow-pitfalls.md
@@ -34,13 +34,20 @@ When you self-reference a composite action inside the same repo that hosts the r
 
 When a workflow run is created, GitHub records the resolved SHAs of every `uses: org/repo/...@ref` at that moment. **Re-running the same run replays those exact SHAs** — it does not re-evaluate the refs. This means: if you fix a bug in an upstream reusable workflow and merge the fix, then re-run a failed workflow that consumed `@main`, you will get the **old, broken** body.
 
-To pick up upstream changes after merging the fix:
+To pick up upstream changes after merging the fix, you must create a **new** run — the ref is not re-resolved per-job or on rerun:
 
-- Push a new commit to the PR (`git commit --allow-empty -m "trigger ci"` works), or
-- Close + reopen the PR, or
-- Trigger a fresh `workflow_dispatch` run.
+- **PR:** push a new commit (`git commit --allow-empty -m "trigger ci"`), or close + reopen the PR (`gh pr close N && gh pr reopen N`), or trigger a fresh `workflow_dispatch` run.
+- **Scheduled / non-PR repo with no `workflow_dispatch`:** create a throwaway branch at the default-branch SHA to fire a fresh `push` run, then delete it:
 
-`gh run rerun` is fine for genuinely transient failures (network blips, rate limits) — not for "I fixed the upstream reusable workflow."
+  ```bash
+  gh api -X POST repos/O/R/git/refs -f ref=refs/heads/ci/verify -f sha=<sha>
+  gh api -X DELETE repos/O/R/git/refs/heads/ci/verify
+  ```
+- A scheduled-only repo whose default branch has no new commit keeps *displaying* the stale red run until its next push/schedule — the fix is in, the badge just hasn't refreshed.
+
+`gh run rerun` is fine for genuinely transient failures (network blips, rate limits) — not for "I fixed the upstream reusable workflow." (Distinct from the consumer's own base-SHA staleness; see `gh-cli-reference.md` → "`gh run rerun` re-runs the OLD state".)
+
+> **Re-triggering a tag workflow** after fixing the workflow file requires **moving the tag** (delete the remote tag, re-tag the fixed default-branch tip, push) — tag events fire against the workflow file *at the tag's commit*. DANGER: only safe when the package is on **no** registry — Packagist/npm webhooks publish within seconds and stable versions are immutable. "The release workflow failed" does not mean nothing was published; check the registry first and prefer fix-forward with a patch version.
 
 ## 4. Permissions ceiling — caller cannot grant what it lacks
 
@@ -95,3 +102,14 @@ Per-project patches defeat the point of the reusable workflow: they reintroduce 
 Before adding a guard, check, or fix to a project's own workflow files, ask whether the shared reusable-workflow repo already owns that concern — or should. If it does, land the change there and let the consumer pick it up via its `@main` / `@vX.Y.Z` reference (per [`reusable-workflow-security.md`](./reusable-workflow-security.md), internal reusable workflows are referenced by tag/branch, not SHA). Keep logic in a consumer only when it is genuinely project-specific.
 
 This is distinct from pitfalls #1–#5 above (which cover *how* to author and reference reusable workflows) — this is about *where* a fix belongs.
+
+## 7. Run with zero jobs whose name is the file path = workflow-validation failure
+
+A run with `conclusion: startup_failure` (or `failure`), **zero jobs**, and a displayed name that falls back to the workflow **file path** failed at workflow *validation*, before any job started. The exact reason is **only in the Actions UI banner** — it is not exposed via the REST API (`gh run view --log[-failed]` returns "log not found"; run/annotations/check-suite endpoints are empty). If you can't see the UI, ask for the banner text. Two causes seen in practice:
+
+1. **Dead reusable-workflow reference** — a `uses:` pointing at a reusable workflow file that no longer exists (e.g. a deleted shared workflow); callers fail silently, sometimes for months. Inspect the `uses:` lines and `gh api`/`curl` the referenced files for 404.
+2. **Permission mismatch** — the caller's job omits an explicit `permissions:` block, the repo's `default_workflow_permissions` is `read`, but a nested reusable job requests e.g. `security-events: write`. UI error: "The nested job 'X' is requesting 'security-events: write', but is only allowed 'security-events: none'." Deceptive because a **byte-identical** workflow file passes in sibling repos whose repo-default permissions are permissive — it is repo-environmental, not a file diff. Fix at the caller per pitfall #4: grant the calling job exactly the scopes the reusable declares.
+
+```bash
+gh api repos/O/R/actions/permissions --jq .default_workflow_permissions   # reveals a restrictive 'read' default
+```


### PR DESCRIPTION
## Why

These are battle-tested GitHub PR/CI/merge-gate gotchas accumulated from repeated field use across many repos. They were living in private project memory; they belong in the shared skill so every agent run benefits instead of re-discovering each trap. Each lesson is generalized — host/ticket/user specifics stripped, only the transferable rule kept.

## What

Integrated 14 lessons into the most fitting existing reference (no new files, SKILL.md untouched):

**`gh-cli-reference.md`**
- Use the native CI watcher (`gh pr checks --watch` / `gh run watch`) instead of hand-rolled poll loops — documents the three recurring watcher bugs (empty-string `conclusion`, premature 0-pending snapshot, wrong `createdAt` cutoff).
- `gh run rerun` re-runs the OLD pinned state (merge-commit base) — only correct for genuine infra flakes (registry pull timeouts, Sigstore 409s, codecov partials).
- Rapid `gh api` calls intermittently 401; the `while read` consumes-error-text trap.
- Add images to an issue/PR via a fork branch + `raw.githubusercontent.com` URL (no browser needed).

**`merge-strategy.md`**
- Diagnose `BLOCKED` before naming a cause; `reviewThreads` is GraphQL-only, not a `gh pr view --json` field.
- Never merge over an announced/in-flight review (`reviewRequests: []` is not "all clear").
- `gh pr merge` false "base branch policy prohibits the merge" → REST `PUT .../merge` fallback (only after the gate is truly verified).
- Merge-method ruleset deadlock (org `allowed_merge_methods` ∩ repo flags = empty; `--admin` can't bypass).
- Copilot-quota ruleset → admin-merge when all real checks are green.
- SonarCloud new-code re-attribution on refactors → fix cheap wins, document-and-merge the residue.

**`pr-commit-cleanup.md`**
- Never reset a PR's head ref to its base commit — it auto-closes the PR.

**`reusable-workflow-pitfalls.md`**
- Fresh-run recipes for scheduled/non-PR repos after fixing a shared `@main` reusable; moving-tag caveat (registry immutability).
- Zero-jobs `startup_failure` diagnosis (dead reusable reference vs. permission mismatch).

### Source memory → reference

| Source memory | Reference |
|---|---|
| gh-cli-burst-401s | gh-cli-reference.md |
| gh-pr-checks-watch-not-handrolled | gh-cli-reference.md |
| gh-run-rerun-stale-merge-sha | gh-cli-reference.md |
| gh-image-attachments-drag-drop | gh-cli-reference.md |
| merge-gate-clean-is-not-head-reviewed | merge-strategy.md |
| merge-method-ruleset-deadlock | merge-strategy.md |
| copilot-review-ruleset-quota-admin-merge | merge-strategy.md |
| blocked-means-diagnose-never-assume-review | merge-strategy.md |
| gh-merge-graphql-policy-false-positive | merge-strategy.md |
| sonar-pr-gate-refactor-attribution | merge-strategy.md |
| never-reset-pr-branch-to-base | pr-commit-cleanup.md |
| reusable-workflow-ref-pinned-at-run-creation | reusable-workflow-pitfalls.md |
| gha-zero-jobs-startup-failure | reusable-workflow-pitfalls.md |
| gha-dockerhub-pull-flake | gh-cli-reference.md (rerun-for-flakes) |

All four files pass markdownlint-cli2 and the repo pre-commit suite.
