### PR TITLE
docs: nameless package.json pollutes lockfile with worktree dir name

### DIFF
--- a/skills/github-project/references/dependency-management.md
+++ b/skills/github-project/references/dependency-management.md
@@ -677,6 +677,33 @@ Or add a `.gitleaks.toml` allowlist for known false positives.
 
 PRs modifying workflow files require manual merge by a repository admin.
 
+### Nameless `package.json` Pollutes the Lockfile With the Worktree Dir Name
+
+**Problem:** Working a Dependabot/Renovate npm PR in a git worktree (e.g. `fix-dependabot-npm-uuid/`) and running `npm install` produces a spurious `package-lock.json` change — the root package `"name"` flips to the worktree directory name — that a reviewer or CI flags as an unrelated diff.
+
+**Cause:** When `package.json` has **no `name` field**, npm falls back to stamping the **checkout directory name** into `package-lock.json` as the root package name. In the git-worktree convention the checkout dir is *branch-named* (e.g. `fix-dependabot-npm-uuid`) rather than the repo name, so every `npm install` rewrites the lockfile's `name` to whatever branch folder you happen to be in.
+
+```jsonc
+// package-lock.json after `npm install` in a worktree named fix-dependabot-npm-uuid/
+{
+  "name": "fix-dependabot-npm-uuid",   // ← polluted: was absent / repo name before
+  "lockfileVersion": 3,
+  ...
+}
+```
+
+**Solution:** Add an explicit `name` field to `package.json` so npm stops deriving it from the directory:
+```jsonc
+// package.json
+{
+  "name": "my-repo",
+  "version": "1.0.0",
+  ...
+}
+```
+
+The lockfile `name` then stays stable regardless of which worktree folder you run `npm install` in. This bites specifically in git-worktree workflows; a plain clone (dir == repo name) masks it.
+
 ## Comparison: Dependabot vs Renovate
 
 | Feature | Dependabot | Renovate |

--- a/skills/github-project/references/dependency-management.md
+++ b/skills/github-project/references/dependency-management.md
@@ -679,9 +679,9 @@ PRs modifying workflow files require manual merge by a repository admin.
 
 ### Nameless `package.json` Pollutes the Lockfile With the Worktree Dir Name
 
-**Problem:** Working a Dependabot/Renovate npm PR in a git worktree (e.g. `fix-dependabot-npm-uuid/`) and running `npm install` produces a spurious `package-lock.json` change — the root package `"name"` flips to the worktree directory name — that a reviewer or CI flags as an unrelated diff.
+**Problem:** Working on a Dependabot/Renovate npm PR in a git worktree (e.g. `fix-dependabot-npm-uuid/`) and running `npm install` produces a spurious `package-lock.json` change — the root package `"name"` flips to the worktree directory name — that a reviewer or CI flags as an unrelated diff.
 
-**Cause:** When `package.json` has **no `name` field**, npm falls back to stamping the **checkout directory name** into `package-lock.json` as the root package name. In the git-worktree convention the checkout dir is *branch-named* (e.g. `fix-dependabot-npm-uuid`) rather than the repo name, so every `npm install` rewrites the lockfile's `name` to whatever branch folder you happen to be in.
+**Cause:** When `package.json` has **no `name` field**, npm falls back to stamping the **checkout directory name** into `package-lock.json` as the root package name. In the git worktree convention, the checkout dir is *branch-named* (e.g. `fix-dependabot-npm-uuid`) rather than the repo name, so every `npm install` rewrites the lockfile's `name` to whatever branch folder you happen to be in.
 
 ```jsonc
 // package-lock.json after `npm install` in a worktree named fix-dependabot-npm-uuid/
@@ -702,7 +702,7 @@ PRs modifying workflow files require manual merge by a repository admin.
 }
 ```
 
-The lockfile `name` then stays stable regardless of which worktree folder you run `npm install` in. This bites specifically in git-worktree workflows; a plain clone (dir == repo name) masks it.
+The lockfile `name` then stays stable regardless of which worktree folder you run `npm install` in. This bites specifically in git worktree workflows; a plain clone (dir == repo name) masks it.
 
 ## Comparison: Dependabot vs Renovate
 


### PR DESCRIPTION
## Summary

From a cross-session retrospective (2026-06-27): a recurring npm-in-a-worktree gotcha.

When `package.json` has **no `name` field**, `npm install` stamps the **checkout directory name** into `package-lock.json` as the root package name. In the git-worktree convention the checkout dir is *branch-named* (e.g. a Dependabot worktree like `fix-dependabot-npm-uuid/`) rather than the repo name, so every `npm install` rewrites the lockfile's `name` — producing a spurious diff a reviewer or CI flags. Fix: add an explicit `name` field to `package.json`. A plain clone (dir == repo name) masks the issue, which is why it surfaces specifically in worktree workflows.

## Changes

- `skills/github-project/references/dependency-management.md` — new "Nameless `package.json` Pollutes the Lockfile With the Worktree Dir Name" subsection under **Troubleshooting Auto-merge** (Problem/Cause/Solution, matching the existing house style). No new file; linked reference already enumerated in SKILL.md.

## Notes

- **No SKILL.md change** — it sits at the ~500-word cap; this is references-only.
- **No version bump** — `plugin.json` and `SKILL.md` are already in sync at `2.15.3` and the parity check only enforces they match each other, not that they change for a docs/references edit.
- Local validation (pre-commit): markdownlint-cli2, check-version-parity, trailing-whitespace, end-of-file-fixer all **Passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)