### PR TITLE
docs(skill): add no-editorializing rule for written output

### DIFF
--- a/skills/github-project/SKILL.md
+++ b/skills/github-project/SKILL.md
@@ -17,18 +17,18 @@ GitHub repository configuration, troubleshooting, and collaboration workflow bes
 ## When to Use
 
 - **Post `gh repo create` + initial push, before first PR** — apply branch protection (REQUIRED, see below)
-- PR won't merge, BLOCKED, or unresolved threads
-- Auto-merge fails for Dependabot/Renovate
-- Solo maintainer auto-approve
-- Branch protection, rulesets, `enforce_admins`
-- GHA failures or permission issues
-- Signed commit merge (rebase can't auto-sign)
-- CodeQL default vs custom workflows
-- Scorecard (token perms, pinned deps)
-- CODEOWNERS, templates, release labels
-- Fork PR merge base
+- PR won't merge / threads
+- Auto-merge fails (Dependabot/Renovate)
+- Solo auto-approve
+- Branch protection, rulesets
+- GHA failures
+- Signed-commit merge
+- CodeQL
+- Scorecard
+- CODEOWNERS, templates, labels
+- Fork PR base
 
-> **REQUIRED post `gh repo create`:** `scripts/init-branch-protection.sh OWNER/REPO` — see `references/repo-bootstrap.md` (closes [snipe-it#17](https://github.com/netresearch/snipe-it-docker-compose-stack/pull/17) class).
+> **REQUIRED post `gh repo create`:** `scripts/init-branch-protection.sh OWNER/REPO` — see `references/repo-bootstrap.md`.
 
 ## Quick Diagnostics
 
@@ -45,7 +45,7 @@ Use `assets/pr-quality.yml.template` for auto-approve with `required_approving_r
 
 ### Auto-merge Setup
 
-Requires `allow_auto_merge`, `pull_request_target` trigger, `user.login` bot detection, `gh pr merge --auto` with dynamic strategy. See `references/auto-merge-guide.md`.
+Requires `allow_auto_merge`, `pull_request_target`, bot detection, `gh pr merge --auto`. See `references/auto-merge-guide.md`.
 
 ### Auto-merge Not Working
 
@@ -84,6 +84,10 @@ scripts/init-branch-protection.sh OWNER/REPO --from-current-checks   # after fir
 scripts/verify-github-project.sh /path/to/repository      # local-checkout audit
 ```
 
+## No editorializing
+
+State what a change does, not how good it is; no self-praise or narrating the expected. See `references/no-editorializing.md`.
+
 ## References
 
 | Topic | Reference |
@@ -101,6 +105,7 @@ scripts/verify-github-project.sh /path/to/repository      # local-checkout audit
 | Scorecard, CodeQL, security | `references/security-config.md` |
 | actionlint | `references/actionlint-guide.md` |
 | Workflow bash pitfalls | `references/workflow-bash-patterns.md` |
+| No editorializing | `references/no-editorializing.md` |
 | Fork merge base | `references/pr-commit-cleanup.md` |
 | Multi-repo batch ops | `references/multi-repo-operations.md` |
 | Reusable workflow security | `references/reusable-workflow-security.md` |

--- a/skills/github-project/SKILL.md
+++ b/skills/github-project/SKILL.md
@@ -26,7 +26,7 @@ GitHub repository configuration, troubleshooting, and collaboration workflow bes
 - CodeQL
 - Scorecard
 - CODEOWNERS, templates, labels
-- Fork PR base
+- Fork PR merge base
 
 > **REQUIRED post `gh repo create`:** `scripts/init-branch-protection.sh OWNER/REPO` — see `references/repo-bootstrap.md`.
 

--- a/skills/github-project/references/no-editorializing.md
+++ b/skills/github-project/references/no-editorializing.md
@@ -1,4 +1,4 @@
-## No editorializing — inform, don't sell (tone, not wordlist)
+# No editorializing — inform, don't sell (tone, not wordlist)
 
 Applies to every written artifact: commit messages, PR/MR descriptions, review
 comments, issue/ticket text, chat — and code comments, docstrings,
@@ -9,7 +9,7 @@ banned-word list catches it, and the same word can be fine or not depending on
 whether it carries a fact. The failure is writing about *how good, clean, or
 careful the work is* instead of *what it does*. The reader has the diff and the
 artifact; anything that only flatters the work or reassures them adds nothing,
-and to a reviewer it reads as salesmanship — it provokes a contra-reaction
+and to a reviewer it reads as salesmanship — it provokes a counter-reaction
 before they reach the substance.
 
 Apply three tests before a sentence stays:

--- a/skills/github-project/references/no-editorializing.md
+++ b/skills/github-project/references/no-editorializing.md
@@ -1,0 +1,41 @@
+## No editorializing — inform, don't sell (tone, not wordlist)
+
+Applies to every written artifact: commit messages, PR/MR descriptions, review
+comments, issue/ticket text, chat — and code comments, docstrings,
+documentation, README and changelog files.
+
+Editorializing is a matter of **tone and intent, not specific words** — no
+banned-word list catches it, and the same word can be fine or not depending on
+whether it carries a fact. The failure is writing about *how good, clean, or
+careful the work is* instead of *what it does*. The reader has the diff and the
+artifact; anything that only flatters the work or reassures them adds nothing,
+and to a reviewer it reads as salesmanship — it provokes a contra-reaction
+before they reach the substance.
+
+Apply three tests before a sentence stays:
+
+1. **Deletion** — remove the phrase. Did the reader lose a fact? If not, cut it.
+2. **Subject** — is the sentence about the change, or about *you / your work*
+   (its quality, your diligence)? The latter goes.
+3. **Voice** — would a terse maintainer write this, or does it read like a
+   cover letter?
+
+Two recurring failure modes:
+
+- **Announcing the expected.** Passing tests, clean linters, "documented", "no
+  regressions", "works as expected" are the baseline — do not narrate them.
+  State a check's status only to flag an *exception* (something knowingly
+  failing or skipped). In a test/verification list, say what was *added or
+  covered*, not that it is green.
+
+- **Self-praise and reassurance.** Grading your own output ("clean", "robust",
+  "elegant", "foolproof", "tidy", "genuinely new", "production-ready"); framings
+  that reassure ("the honest breaking change", "deliberately scoped, not
+  hidden", "where it belongs"); and the diligence humble-brag ("I carefully…",
+  "I made sure to…", "thoroughly tested"). These describe the author, not the
+  change. Show the fact; drop the framing. (The words are only symptoms — judge
+  by the three tests above, not by the word.)
+
+Use plain labels, not graded ones: "Breaking change", "Tests", "Limitations" —
+not "Tests (all green)" or "Breaking change (honest)". If a limitation's cause
+matters, it is already stated in the item.


### PR DESCRIPTION
Adds a `## No editorializing` note and `references/no-editorializing.md`: write what a change does, not how good or careful the work is — no narrating expected results or self-praise. Judged by tone (deletion / subject / voice tests), not a wordlist. SKILL.md kept under the 500-word limit by tightening a few triggers/prose. Mirrors netresearch/git-workflow-skill#83.