### PR TITLE
docs: propagate shared-workflow CI/security/dependabot learnings

### DIFF
--- a/skills/github-project/SKILL.md
+++ b/skills/github-project/SKILL.md
@@ -12,7 +12,7 @@ allowed-tools: Bash(gh:*) Bash(git:*) Bash(grep:*) Read Write
 
 # GitHub Project Skill
 
-GitHub repository configuration, troubleshooting, and collaboration workflow best practices.
+GitHub repository configuration, troubleshooting, and collaboration.
 
 ## When to Use
 
@@ -108,6 +108,7 @@ State what a change does, not how good it is; no self-praise or narrating the ex
 | No editorializing | `references/no-editorializing.md` |
 | Fork merge base | `references/pr-commit-cleanup.md` |
 | Multi-repo batch ops | `references/multi-repo-operations.md` |
+| Cross-repo references | `references/cross-repo-references.md` |
 | Reusable workflow security | `references/reusable-workflow-security.md` |
 | Reusable workflow pitfalls | `references/reusable-workflow-pitfalls.md` |
 | Org security settings | `references/org-security-settings.md` |

--- a/skills/github-project/references/actionlint-guide.md
+++ b/skills/github-project/references/actionlint-guide.md
@@ -476,3 +476,24 @@ Verify after writing:
 # Bytes at end of file — should be `0a` (one newline), not `0a0a`.
 tail -c 2 file.yml | xxd -p
 ```
+
+### `docker://IMAGE@sha256:DIGEST` fails workflow startup
+
+Also unrelated to actionlint's own checks (it does not flag this), but a sharp adjacent gotcha when SHA-pinning tools in a gate: a `uses:` step referencing a Docker image by **digest** fails the entire run at startup with `startup_failure` — no job even begins:
+
+```yaml
+# ✗ startup_failure — digest form is NOT accepted for docker:// refs
+- uses: docker://rhysd/actionlint@sha256:b1934e...
+
+# ✓ tag form is accepted
+- uses: docker://rhysd/actionlint:1.7.12
+```
+
+`docker://` action refs take `image:tag` only. To get digest-level reproducibility, don't use `docker://` — download the release binary and verify its checksum in a `run:` step (fails closed on mismatch):
+
+```bash
+curl -sSfL -o actionlint.tar.gz \
+  "https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_linux_amd64.tar.gz"
+echo "<sha256>  actionlint.tar.gz" | sha256sum -c -
+tar xzf actionlint.tar.gz actionlint
+```

--- a/skills/github-project/references/cross-repo-references.md
+++ b/skills/github-project/references/cross-repo-references.md
@@ -1,0 +1,54 @@
+# Cross-Repo Issue/PR References in Markdown
+
+GitHub autolinks a bare `#NN` in an issue/PR/comment body to an issue or PR **in
+the same repository**. When the number belongs to a *different* repo, a bare
+`#NN` silently links to the wrong target — it does not error, it renders as a
+valid link pointing somewhere unintended.
+
+## The trap
+
+The failure is invisible in the source and only wrong at render time. It bites
+hardest in a repo literally named `.github`, where a stray `#137` resolves to
+`owner/.github#137` — usually an unrelated PR that happens to share the number.
+
+```markdown
+<!-- Written in owner/.github, meaning owner/other-repo#137 -->
+root-caused via owner/other-repo#136 / #137
+                                        ^^^^  links to owner/.github#137 — WRONG
+```
+
+Note that `owner/other-repo#136` is fine (it carries the repo), while the
+adjacent bare `#137` is not — mixed forms in one sentence are a common source of
+this bug.
+
+## The rule
+
+A cross-repo reference must carry the repo. Use one of:
+
+```markdown
+owner/repo#137                                   <!-- full autolink form -->
+[#137](https://github.com/owner/repo/pull/137)   <!-- explicit markdown link -->
+```
+
+A bare `#137` is correct **only** when it targets the same repo the body lives
+in. When in doubt, use the explicit markdown link — it is unambiguous and
+survives the body being copied into another repo.
+
+## Verifying before you post
+
+Render the body through GitHub's GFM API and check where each reference actually
+points, rather than eyeballing the source:
+
+```bash
+jq -Rs --arg ctx "owner/repo" '{text:., mode:"gfm", context:$ctx}' body.md \
+  | gh api -X POST /markdown --input - \
+  | grep -oE 'href="[^"]*/(pull|issues)/[0-9]+"'
+```
+
+Any `href` pointing at a repo you did not intend is a bare-reference bug — fix
+it to `owner/repo#NN` or a markdown link. A quick pre-scan for the risky pattern
+(a `#NN` not preceded by a repo name) narrows where to look:
+
+```bash
+grep -noE '[^/A-Za-z0-9_.-]#[0-9]+' body.md
+```

--- a/skills/github-project/references/dependency-management.md
+++ b/skills/github-project/references/dependency-management.md
@@ -66,6 +66,43 @@ gh run view <RUN_ID> --repo OWNER/REPO --log-failed |
 
 If the failure comes from a template-derived ecosystem that doesn't apply: fix the template (so new consumers inherit the fix) *and* open a consumer-side PR to drop the ecosystem (so the existing repo stops failing). Running only one half leaves the drift check failing on the PR or the schedule failing on main. See [multi-repo-operations.md](./multi-repo-operations.md) for the template-consumer coordination pattern.
 
+### Maintained Release Branches — `target-branch`
+
+Dependabot scans **only the default branch** by default. A repo that keeps long-lived release branches (e.g. `13.4`, `12.4` alongside `main`) receives action/dependency bumps on the default branch only; the release branches silently fall behind and their pinned actions go stale — a divergence nobody notices until, say, a backport PR renders with an old pinned action while `main` already moved on.
+
+Add one update block **per maintained branch** with `target-branch`:
+
+```yaml
+version: 2
+updates:
+  # Default branch
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: weekly
+
+  # Maintained release branches — Dependabot only scans the default branch
+  # otherwise, so these bump the branch in place (no backport needed).
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "13.4"
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "12.4"
+    schedule:
+      interval: weekly
+```
+
+Notes:
+
+- `target-branch` PRs open **against that branch**, not the default — no backport labels or cherry-picks involved.
+- List only branches that actually exist and are maintained; a `target-branch` pointing at a missing branch makes that update run **fail** (visible in the repo's Dependabot update logs — see "Diagnosing a weekly Dependabot failure" above), it does not silently no-op.
+- The alternative — labeling default-branch bump PRs for backport — works but reintroduces per-PR conflict resolution once branch workflows have drifted; `target-branch` bumps in place instead.
+- `groups`, `cooldown`, `commit-message`, and `open-pull-requests-limit` apply per block.
+
 ### Grouping Dependencies
 ```yaml
 updates:

--- a/skills/github-project/references/reusable-workflow-security.md
+++ b/skills/github-project/references/reusable-workflow-security.md
@@ -135,3 +135,94 @@ jobs:
 Org secrets do **not** auto-propagate into reusable workflows either — each
 caller must forward them explicitly, which is what makes `inherit` look
 convenient. Resist it; the explicit form is also the audit trail.
+
+## Gating Your Own Shared-Workflow Repo
+
+The sections above are about auditing **external** actions before you adopt
+them. This one is about the shared-workflow repo you **own**: because consumers
+reference it at `@main`, every merge ships to all of them instantly — a broken
+or insecure merge propagates org-wide before anyone reviews it. Gate `main` and
+every PR with more than a linter:
+
+| Dimension | Tool | Catches |
+|-----------|------|---------|
+| Lint | [actionlint](https://github.com/rhysd/actionlint) | Syntax, expression/input types, shellcheck on `run:` blocks |
+| Style | [yamllint](https://github.com/adrienverge/yamllint) `--strict` | YAML conformance |
+| Security | [zizmor](https://docs.zizmor.sh/) | Template injection, credential persistence, token misuse, missing cooldown |
+| Conformance | small repo script | README ↔ workflow-file sync, `workflow_call`-only triggers, documented inputs |
+
+### zizmor findings you *will* hit, and the correct fix
+
+- **`artipacked` (credential persistence):** every `actions/checkout` on a
+  read-only job needs `persist-credentials: false`, or the `GITHUB_TOKEN` is
+  written to `.git/config` where any later `run:` step — or a compromised
+  npm/composer postinstall — can read it.
+
+  ```yaml
+  - uses: actions/checkout@<sha>
+    with:
+      persist-credentials: false
+  ```
+
+- **`template-injection` on `run: ${{ inputs.x }}`:** for a *flag-list* input
+  (`render-flags`, `composer-args`), route it through an `env:` var so it is
+  never expanded into the script text:
+
+  ```yaml
+  - env:
+      RENDER_FLAGS: ${{ inputs.render-flags }}
+    run: |
+      # shellcheck disable=SC2086  # intended word-splitting of a flag list
+      tool $RENDER_FLAGS
+  ```
+
+  For a *whole-command* input that must be shell-interpreted (`command`,
+  `test-unit-command`), env indirection is impossible — the input **is** code.
+  Accept it as "code by contract" (set in the caller's committed workflow, the
+  same trust level as the code) with a justified inline ignore, and document the
+  contract:
+
+  ```yaml
+  # Command inputs are code by contract: set in the caller's committed workflow.
+  - run: ${{ inputs.command }}  # zizmor: ignore[template-injection]
+  ```
+
+  In the input `description:` and the README, state: *command inputs must be
+  static literals — never pass `github.event.*` data.* That closes the one real
+  injection path the ignore leaves open (a careless consumer piping a PR title
+  into the input).
+
+- **`github-app` (unscoped token):** `actions/create-github-app-token` without
+  `permission-*` inputs mints a token carrying **all** of the App's granted
+  permissions. Scope it to what the job needs: `permission-contents: write`,
+  `permission-pull-requests: write`, etc.
+
+### Pin the gate's own tooling
+
+The gate is only as trustworthy as the tools it installs.
+
+- **pip tools** — hash-lock them; don't `pip install foo==1.2.3` bare:
+
+  ```bash
+  # requirements.txt generated with: uv pip compile --generate-hashes
+  pip install --require-hashes --only-binary ':all:' -r .github/requirements.txt
+  ```
+
+  Add a `pip` Dependabot ecosystem (`directory: /.github`) so the pins stay
+  fresh.
+
+- **CLI binaries** — download by pinned version and verify the checksum, failing
+  closed on mismatch:
+
+  ```bash
+  curl -sSfL -o actionlint.tar.gz \
+    "https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_linux_amd64.tar.gz"
+  echo "<sha256>  actionlint.tar.gz" | sha256sum -c -
+  tar xzf actionlint.tar.gz actionlint
+  ```
+
+  A curl-installed binary is **not** covered by Dependabot — bump its version +
+  checksum by hand, and note that in a comment so it is not mistaken for
+  auto-maintained. (Do **not** try to pin it via `uses: docker://IMAGE@sha256:…`
+  — digest-form `docker://` refs fail workflow startup; see
+  [`actionlint-guide.md`](./actionlint-guide.md).)


### PR DESCRIPTION
## Summary

Propagates four learnings from a session hardening the TYPO3-Documentation shared-workflows repo into the `github-project` references, so they don't have to be rediscovered.

## Came from

`/retro` session on 2026-07-04 (session `3c444d0c`). Root friction: a backport rendered with an old pinned `actions/checkout` because bumps only reached the default branch, plus a "you added only linting … no security checks?" correction on the CI gate.

## Change

Four atomic doc commits:

1. **`dependency-management.md`** — Dependabot scans only the default branch; maintained release branches drift. Adds a `target-branch` section (per-branch update blocks bump in place, no backport needed).
2. **`reusable-workflow-security.md`** — new "Gating Your Own Shared-Workflow Repo" section: the existing ref covered auditing *external* actions; this covers the four-dimension gate (lint/style/security/conformance) for the repo you own, the concrete zizmor fixes teams hit first (`artipacked` → `persist-credentials: false`; `template-injection` → env indirection or documented code-by-contract ignore; unscoped app token), and hash-pinning the gate's own pip/binary tooling.
3. **`actionlint-guide.md`** — `uses: docker://IMAGE@sha256:…` digest refs fail workflow startup (`startup_failure`); use `image:tag` or a checksum-verified binary download.
4. **`cross-repo-references.md`** (new) — bare `#NN` in a repo (esp. `.github`) autolinks to *that* repo, not the intended one; use `owner/repo#NN` or a markdown link, and a GFM-API render check to verify. Added to the SKILL.md reference index.

## Test plan

- [x] `markdownlint-cli2` clean on all changed files (repo config)
- [x] All commits DCO signed-off + GPG signed
- [x] Reference files end with a single newline
- [ ] Maintainer review of the new security guidance for accuracy
