### PR TITLE
docs(github-project): GitHub Pages publishing + org-data-collector pitfalls

### DIFF
--- a/skills/github-project/SKILL.md
+++ b/skills/github-project/SKILL.md
@@ -12,7 +12,7 @@ allowed-tools: Bash(gh:*) Bash(git:*) Bash(grep:*) Read Write
 
 # GitHub Project Skill
 
-GitHub repository configuration, troubleshooting, and collaboration.
+Repository configuration, troubleshooting, and collaboration.
 
 ## When to Use
 
@@ -86,18 +86,18 @@ scripts/verify-github-project.sh /path/to/repository      # local-checkout audit
 
 ## No editorializing
 
-State what a change does, not how good it is; no self-praise or narrating the expected. See `references/no-editorializing.md`.
+State what a change does, not how good it is; no self-praise. See `references/no-editorializing.md`.
 
 ## References
 
 | Topic | Reference |
 |-------|-----------|
-| Repo bootstrap (post `gh repo create`) | `references/repo-bootstrap.md` |
+| Repo bootstrap | `references/repo-bootstrap.md` |
 | Repository file layout | `references/repository-structure.md` |
 | Branch migration | `references/branch-migration.md` |
 | Dependabot/Renovate | `references/dependency-management.md` |
 | Auto-approve + auto-merge | `references/auto-merge-guide.md` |
-| Merge strategy (signed commits) | `references/merge-strategy.md` |
+| Merge strategy | `references/merge-strategy.md` |
 | Sub-issues | `references/sub-issues.md` |
 | Release labeling | `references/release-labeling.md` |
 | gh CLI commands | `references/gh-cli-reference.md` |
@@ -115,6 +115,7 @@ State what a change does, not how good it is; no self-praise or narrating the ex
 | Tag validation | `references/tag-validation.md` |
 | AI reviewer pushback | `references/ai-reviewer-pushback.md` |
 | Agentic workflows | `references/agentic-workflows.md` |
+| Pages + data collectors | `references/pages-and-collector-workflows.md` |
 
 ---
 

--- a/skills/github-project/references/pages-and-collector-workflows.md
+++ b/skills/github-project/references/pages-and-collector-workflows.md
@@ -1,0 +1,30 @@
+# Publishing a generated site to GitHub Pages (and org-data collectors)
+
+Lessons from shipping a nightly workflow that inventories an organization's repos and publishes a generated dashboard to GitHub Pages. Two classes of failure that a `200 OK` and a green build both hide.
+
+## Hidden rate limits break the workflow and the deploy
+
+A workflow that walks an org (per-repo file probes + issue/PR counts) exhausts limits that are separate from the familiar 5,000/hour user quota:
+
+- **`GITHUB_TOKEN` installation limit — ~1,000 requests/hour, scoped to the repository the workflow runs in** (where the token is issued — *not* a separate quota per target repo you query). This is the token Actions injects, *distinct* from a PAT's 5,000/hr user limit. A collector that spends ~15 `GET /repos/{repo}/contents/{path}` probes per repo across ~100 target repos burns ~1,500 calls against that single budget and exhausts it — after which the **`deploy-pages` step 403s** ("API rate limit exceeded for installation") even though it makes one call. The build job starves the deploy job because they share the one installation quota.
+- **Search API primary limit — 30 requests/minute (authenticated).** `GET /search/issues` for open-issue/PR/stale counts hits this within the first minute across a large org, and rate-limited responses come back as **403 that looks like "no data"** — counts silently become `null`/0 and the dashboard shows wrong numbers with a green build.
+
+### Fixes
+
+- **File presence: one `git/trees` call per repo, not N `contents` probes.** `GET /repos/{owner}/{repo}/git/trees/{ref}?recursive=1` returns the whole file listing in one request; test for `README`/`CODEOWNERS`/`SECURITY`/etc. against that set. ~3 calls/repo instead of ~15.
+- **Counts: GraphQL, not the Search API.** One GraphQL sweep over `organization.repositories` returning `issues(states:OPEN){totalCount}` and `pullRequests(states:OPEN){totalCount}` is accurate for every repo and spends a handful of the 5,000-point/hour GraphQL budget. For stale-PR counts use `pullRequests(states:OPEN, first:100, orderBy:{field:UPDATED_AT, direction:ASC}){nodes{updatedAt}}` — `orderBy` takes an `IssueOrder` **object** (`{field,direction}`), not a bare enum; ASC lets you stop once past the cutoff, and you must paginate (or cap and flag) for repos with >100 open PRs or the count is silently low.
+- **Retry only what's transient.** Retry 5xx and secondary-rate-limit responses (they carry `Retry-After`); let the primary Search limit fast-degrade to `null` rather than blocking. One flaky response should not abort a run whose output is written only at the end.
+- **Budget the run.** Keep a full collection under ~1,000 REST calls so the shared installation token survives the `deploy-pages` job in the same workflow.
+
+## A Pages "200 OK" is not proof the page rendered
+
+For a **JS-rendered** page (data embedded in the HTML, DOM built client-side), `curl` returning `200` with the correct `<title>` proves nothing — the body can be blank. Real incident: a `String.prototype.replace(placeholder, json)` bug (replaces only the first of two identical tokens) shipped `window.{…json…} = __PLACEHOLDER__;` — a syntax error, blank dashboard, green build, 200 response.
+
+- **Verify by rendering, not by status.** Render headless and assert DOM population (a KPI value, a table row), e.g. `google-chrome --headless --dump-dom --virtual-time-budget=5000 <url>` then grep the post-JS DOM; or drive one interaction with Playwright and assert zero console errors.
+- **Don't read deploy success from a Pages endpoint 404.** There is no `GET /repos/{o}/{r}/pages/deployments` list endpoint (it 404s); list deployments via `GET /repos/{o}/{r}/deployments`, or just trust the `deploy` job's own conclusion.
+
+## Verify a workflow edit actually landed before claiming it
+
+A silent editor failure (edit reported an error, never retried) left GitHub Actions pinned to old `@v4`/`@v3` majors while the summary claimed "SHA-pinned." The **CI annotation** (`Node.js 20 is deprecated…`) exposed it — the pass/fail status did not.
+
+- After editing action versions/pins, read the run's **annotations** and the committed workflow file — do not claim "pinned/updated" from a green check alone. See the "CI Annotations" section in `references/security-config.md`.


### PR DESCRIPTION
Adds `references/pages-and-collector-workflows.md` from a session that published a generated org dashboard to GitHub Pages. Captures failures that a `200 OK` and a green build both hide:

- **`GITHUB_TOKEN` installation rate limit** (~1000 req/hr **per repo**, distinct from the 5000/hr user limit) — exhausted by ~15 per-file `contents` probes × ~100 repos, which then **403s the `deploy-pages` step**. Fix: one `git/trees?recursive=1` call per repo.
- **Search API 30 req/min** primary limit silently nulls issue/PR counts (403 reads as "no data"). Fix: GraphQL for counts.
- A **JS-rendered Pages `200 OK` is not proof it rendered** (a `.replace()` first-occurrence bug shipped a blank page with a green build). Assert DOM headless.
- **Verify action version/pin edits actually landed** — read the run CI annotations, not just the green check.

Linked from the SKILL.md references table. No version bump (leaving that to the maintainer release step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)