### PR TITLE
docs(merge-strategy): stale-green merge refs, strict no-op audit, update-branch signing

### DIFF
--- a/skills/github-project/references/merge-strategy.md
+++ b/skills/github-project/references/merge-strategy.md
@@ -132,6 +132,30 @@ Both are marked as "Verified" in the GitHub UI:
 - Developer commits show the developer's GPG key
 - Merge commits show "Verified" with GitHub as the signer
 
+### "Update branch" and signing (who has to act on "branch out of date")
+
+- **"Update branch" (merge variant)**: the update-merge commit is created and signed by GitHub's web-flow key — satisfies "require signed commits" with zero author involvement. In a squash-merge repo the update commit is squashed away at landing anyway.
+- **"Update with rebase" button / rebase merges**: GitHub **cannot re-sign rewritten commits** — fails on signed-commit-protected repos.
+- **Local rebase**: signature verification is against the **committer**, not the author. Anyone with head-branch push access (author, or maintainers when "Allow edits from maintainers" is on) can `git rebase -S && git push --force-with-lease`, re-signing with *their own* verified key — authorship and `Signed-off-by` trailers survive. The original author does not have to be the one who rebases.
+
+## Stale-green merge refs: two green PRs can still break main
+
+A PR's `pull_request` checks run against a **snapshot merge ref** (`refs/pull/N/merge` = PR + base *at the moment the run starts*). GitHub never re-runs a PR's checks when the base branch moves afterward — the green badge silently goes stale (observed: an 8-day-old green used to merge). Two PRs that are **textually disjoint** (no git conflict, `MERGEABLE`) can be **semantically conflicting** — e.g. one adds a test fixture rendered from a template the other PR changes. Whichever merges second turns main red, and every open PR then inherits the failure through its merge ref.
+
+Mitigations, in increasing strength:
+
+1. **Required checks + strict up-to-date.** `strict: true` ("Require branches to be up to date") applies **only to the contexts listed in `required_status_checks`** — with an empty contexts list it is a **complete no-op**, and red CI does not block merging at all. Audit both together:
+
+   ```bash
+   gh api repos/OWNER/REPO/branches/main/protection \
+     --jq '{strict: .required_status_checks.strict, contexts: .required_status_checks.contexts}'
+   # strict=true + contexts=[] → the flag does nothing; populate contexts
+   ```
+
+2. **Merge queue.** Tests `latest main + queued PRs + this PR` (`merge_group` event) before landing; a semantically conflicting PR is ejected instead of breaking main. Prerequisites: workflows must add a `merge_group:` trigger (or checks never report and the queue stalls), and the queue only gates **required** checks — an empty contexts list makes it vacuous too.
+
+Neither catches a semantic conflict no test covers. Post-merge push CI on the default branch stays the last line of defence — keep it.
+
 ## Troubleshooting
 
 ### Diagnose `mergeStateStatus: BLOCKED` before naming a cause
@@ -289,6 +313,8 @@ If there is no entry and no `merge_group` run after the required checks have pas
 ```bash
 gh pr merge <PR> --repo OWNER/REPO --merge --admin
 ```
+
+> **Scope of this escape hatch:** only in repos whose governance is ours, only for this stuck-queue failure mode, and only with the operator's explicit go for that PR. `--admin` bypasses required reviews and status checks wholesale — on upstream/community repos (or to merge your own unreviewed PR anywhere) it is never appropriate, no matter how trivial the fix or how red the main branch. Holding admin permission is a trust grant, not a merge mandate.
 
 ### Arming a merge queue PR: `--auto` with no strategy flag
 

--- a/skills/github-project/references/merge-strategy.md
+++ b/skills/github-project/references/merge-strategy.md
@@ -144,12 +144,14 @@ A PR's `pull_request` checks run against a **snapshot merge ref** (`refs/pull/N/
 
 Mitigations, in increasing strength:
 
-1. **Required checks + strict up-to-date.** `strict: true` ("Require branches to be up to date") applies **only to the contexts listed in `required_status_checks`** — with an empty contexts list it is a **complete no-op**, and red CI does not block merging at all. Audit both together:
+1. **Required checks + strict up-to-date.** `strict: true` ("Require branches to be up to date") applies **only to the checks listed in `required_status_checks`** (`checks` is the canonical field; `contexts` is its deprecated mirror) — with an empty list it is a **complete no-op**, and red CI does not block merging at all. Audit the flag and both list fields together:
 
    ```bash
    gh api repos/OWNER/REPO/branches/main/protection \
-     --jq '{strict: .required_status_checks.strict, contexts: .required_status_checks.contexts}'
-   # strict=true + contexts=[] → the flag does nothing; populate contexts
+     --jq '{strict: (.required_status_checks?.strict // false),
+            contexts: (.required_status_checks?.contexts // []),
+            checks: (.required_status_checks?.checks // [])}'
+   # strict=true + empty contexts AND checks → the flag does nothing; populate the checks list
    ```
 
 2. **Merge queue.** Tests `latest main + queued PRs + this PR` (`merge_group` event) before landing; a semantically conflicting PR is ejected instead of breaking main. Prerequisites: workflows must add a `merge_group:` trigger (or checks never report and the queue stalls), and the queue only gates **required** checks — an empty contexts list makes it vacuous too.


### PR DESCRIPTION
Three verified learnings from a 2026-07-09 incident in TYPO3-Documentation/render-guides, where two individually green PRs (a template change and a fixture generated against the old template) merged past each other and broke main — every open PR then inherited the failure via its merge ref.

## Additions to `references/merge-strategy.md`

1. **Stale-green merge refs** — `pull_request` checks run on a snapshot merge ref and are never re-run when the base moves (an 8-day-old green was used to merge). Textually disjoint ≠ semantically compatible. Mitigation ladder: required checks + strict up-to-date → merge queue (needs a `merge_group:` trigger and gates only *required* checks).
2. **`strict: true` with empty `required_status_checks.contexts` is a complete no-op** — observed in the wild; the audit one-liner checks `strict` plus the canonical `checks` list and its deprecated `contexts` mirror.
3. **"Update branch" signing matrix** — update-merge commits are web-flow-signed; rebase-updates cannot be re-signed by GitHub; a local re-signing rebase verifies against the *committer's* key, so any maintainer with head-branch push access can do it, not just the author.
4. **Scoping note on the existing stuck-queue `--admin` escape hatch** — own-governance repos only, explicit operator go per PR, never on upstream repos or for one's own unreviewed PR (the incident's second failure mode).
