### PR TITLE
docs(collector): classify 403s and cover the stargazers restriction

### DIFF
--- a/skills/github-project/evals/evals.json
+++ b/skills/github-project/evals/evals.json
@@ -288,5 +288,49 @@
         "pattern": "(manual.*merge|workflows.*permission|cannot.*auto-merge)"
       }
     ]
+  },
+  {
+    "name": "collector_403_stargazers_restriction",
+    "prompt": "Our scheduled workflow that collects stargazers for every org repo suddenly gets 403 on every repo, but it still exits green and reports 0 new stars. Fix it.",
+    "assertions": [
+      {
+        "type": "content",
+        "pattern": "(admin|collaborator).*(stargazer|subscriber)|stargazer.*(admin|collaborator)"
+      },
+      {
+        "type": "content",
+        "pattern": "(fine-grained|PAT|personal access token)"
+      },
+      {
+        "type": "content",
+        "pattern": "(Metadata).*(read)"
+      },
+      {
+        "type": "content",
+        "pattern": "(forks|sibling|other endpoint).*(work|succeed|not fail)|rule(s)? out.*rate limit"
+      }
+    ]
+  },
+  {
+    "name": "classify_403_before_retrying",
+    "prompt": "Our GitHub API client retries every 403 three times with backoff. Is that right?",
+    "assertions": [
+      {
+        "type": "content",
+        "pattern": "(x-ratelimit-remaining|X-RateLimit-Remaining)"
+      },
+      {
+        "type": "content",
+        "pattern": "(retry-after|Retry-After)"
+      },
+      {
+        "type": "content",
+        "pattern": "(secondary rate limit)"
+      },
+      {
+        "type": "content",
+        "pattern": "(permission|not transient|Resource not accessible)"
+      }
+    ]
   }
 ]

--- a/skills/github-project/evals/evals.json
+++ b/skills/github-project/evals/evals.json
@@ -299,11 +299,11 @@
       },
       {
         "type": "content",
-        "pattern": "(fine-grained|PAT|personal access token)"
+        "pattern": "([Ff]ine-grained|PAT|[Pp]ersonal [Aa]ccess [Tt]oken)"
       },
       {
         "type": "content",
-        "pattern": "(Metadata).*(read)"
+        "pattern": "[Mm]etadata.{0,20}[Rr]ead"
       },
       {
         "type": "content",

--- a/skills/github-project/references/pages-and-collector-workflows.md
+++ b/skills/github-project/references/pages-and-collector-workflows.md
@@ -16,6 +16,56 @@ A workflow that walks an org (per-repo file probes + issue/PR counts) exhausts l
 - **Retry only what's transient.** Retry 5xx and secondary-rate-limit responses (they carry `Retry-After`); let the primary Search limit fast-degrade to `null` rather than blocking. One flaky response should not abort a run whose output is written only at the end.
 - **Budget the run.** Keep a full collection under ~1,000 REST calls so the shared installation token survives the `deploy-pages` job in the same workflow.
 
+## Not every 403 is a rate limit — classify before reacting
+
+A collector meets three different 403s, and they need opposite responses. Read the headers rather than the status code:
+
+| 403 | Signal | Response |
+|---|---|---|
+| Primary rate limit | `x-ratelimit-remaining: 0` | Transient. Back off or degrade. |
+| Secondary rate limit | `retry-after` present, *or* only the body says `"secondary rate limit"` | Transient. Honour `retry-after`. |
+| Permission | Neither of the above; body names the cause (`Resource not accessible by integration`) | **Not** transient. Retrying burns the run and hides the cause. |
+
+The secondary limit is the trap: it does **not** zero `x-ratelimit-remaining`, so `remaining == 0` alone misfiles it as a permission error and aborts a run that should have waited. And `retry-after` is sufficient but not necessary — [the docs](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api) only say it *may* be present — so the body is the last resort:
+
+```python
+def is_rate_limited(response):
+    if response.headers.get("X-RateLimit-Remaining") == "0":
+        return True
+    if "Retry-After" in response.headers:
+        return True
+    return "secondary rate limit" in response.text.lower()
+```
+
+**Diagnostic: a sibling endpoint that still works disproves a rate limit in one step.** A budget is token-wide, so it cannot spare one endpoint and starve another. When `/stargazers` 403s on all 278 repos but `/forks` never fails once, on the same token in the same run, the cause is per-endpoint permission — no header reading required.
+
+### Stargazers and subscribers are admin/collaborator-only (since 2026-06-30)
+
+[GitHub restricted](https://github.blog/changelog/2026-06-30-upcoming-access-restrictions-to-public-api-endpoints-and-ui-views/) `GET /repos/{o}/{r}/stargazers` and `GET /repos/{o}/{r}/subscribers` to each repo's admins and collaborators — they were being scraped to harvest user data. `GET /users/{u}/subscriptions` is deprecated and returns empty. The UI views `/stargazers`, `/stargazers/you_know` and `/watchers` are restricted too; `/network/dependents` is not.
+
+- **The Actions `GITHUB_TOKEN` is neither an admin nor a collaborator**, so it 403s on *every* repo — including the one the workflow runs in, with `Metadata: read` granted. `/forks` is unaffected.
+- **Fix: a fine-grained PAT** whose owner is a collaborator. Both endpoints need only [Metadata: read](https://docs.github.com/en/rest/authentication/permissions-required-for-fine-grained-personal-access-tokens), which every fine-grained PAT carries by default — no extra permission to tick, and nothing under "Organization permissions".
+- **The status code differs by token type:** an Actions token gets `403`; a user PAT gets **`404`** on repos where it is not a collaborator (GitHub hides existence rather than admitting the block). Don't read that 404 as "repo gone".
+- A PAT expires. Make the run fail loudly and name the secret, or the collector silently reverts to reporting no news.
+
+## A systemic error must abort; only per-item errors may degrade
+
+"Retry only what's transient" (above) has a corollary: a collector that catches every error per repo, keeps the last known state and exits `0` reports **"0 new"** — indistinguishable from a genuine quiet period. A star-notification collector hid a total outage this way for 9+ days across ~900 runs; nobody was watching a green check that said `Found: 0 star(s)`.
+
+- **Auth failures (401/403-permission) are systemic, never per-item.** Raise a distinct exception that the per-item handler cannot catch, so the job goes red with an actionable annotation:
+  ```python
+  class AuthError(Exception): ...          # not a RequestException
+  ...
+  except requests.exceptions.RequestException:   # per-repo, may degrade
+      return None
+  ```
+- **Read the token with a default, and check it.** `os.environ["TOKEN"]` raises `KeyError` before any handler is installed; worse, Actions sets a *missing* secret to the **empty string**, so the variable exists and the failure is a silent 401. `os.environ.get("TOKEN", "")` plus an explicit emptiness check catches both.
+- **A green run proves nothing on its own — assert on the failure count.** `Found: 0 star(s)` with 0 failed fetches is real; with 556 failed fetches it is an outage.
+
+### Cross-run state: `dawidd6/action-download-artifact` matches any branch
+
+Collectors persist state between runs by uploading an artifact and pulling it back with `dawidd6/action-download-artifact`. Its `branch` input has **no default**, so it takes the latest successful run of the workflow on *any* branch. A `workflow_dispatch` test on a feature branch therefore loads (and its upload then becomes) production state. Convenient for testing a fix against real data; set `branch:` explicitly if you need isolation.
+
 ## A Pages "200 OK" is not proof the page rendered
 
 For a **JS-rendered** page (data embedded in the HTML, DOM built client-side), `curl` returning `200` with the correct `<title>` proves nothing — the body can be blank. Real incident: a `String.prototype.replace(placeholder, json)` bug (replaces only the first of two identical tokens) shipped `window.{…json…} = __PLACEHOLDER__;` — a syntax error, blank dashboard, green build, 200 response.

--- a/skills/github-project/references/pages-and-collector-workflows.md
+++ b/skills/github-project/references/pages-and-collector-workflows.md
@@ -45,6 +45,7 @@ def is_rate_limited(response):
 
 - **The Actions `GITHUB_TOKEN` is neither an admin nor a collaborator**, so it 403s on *every* repo — including the one the workflow runs in, with `Metadata: read` granted. `/forks` is unaffected.
 - **Fix: a fine-grained PAT** whose owner is a collaborator. Both endpoints need only [Metadata: read](https://docs.github.com/en/rest/authentication/permissions-required-for-fine-grained-personal-access-tokens), which every fine-grained PAT carries by default — no extra permission to tick, and nothing under "Organization permissions".
+- **Scope the PAT to *All repositories*, not a hand-picked list** (org policy permitting). A collector walks the org from `GET /orgs/{org}/repos`, so a select-repository PAT keeps discovering repos it may not read: every repo created after the PAT was minted degrades to a permission 403 and, in a collector that swallows per-item errors, disappears from the output with no signal. The failure grows silently as the org does.
 - **The status code differs by token type:** an Actions token gets `403`; a user PAT gets **`404`** on repos where it is not a collaborator (GitHub hides existence rather than admitting the block). Don't read that 404 as "repo gone".
 - A PAT expires. Make the run fail loudly and name the secret, or the collector silently reverts to reporting no news.
 


### PR DESCRIPTION
Came from /retro: yes

## Friction

A scheduled collector in `netresearch/maint` reported `Found: 0 star(s)` and exited green for 9+ days (~900 runs) while every one of its 278 repos 403'd. [GitHub restricted](https://github.blog/changelog/2026-06-30-upcoming-access-restrictions-to-public-api-endpoints-and-ui-views/) `stargazers` and `subscribers` to admins/collaborators on 2026-06-30; the Actions `GITHUB_TOKEN` is neither.

`pages-and-collector-workflows.md` is the closest thing we have to a guide for exactly this workflow — but it only knows one cause for a collector 403 (rate limits), and its "retry only what's transient" advice retried this one 3× each, stretching the job to 37 minutes and 1670 log lines. Following the skill as written would not have diagnosed it.

## Change

`references/pages-and-collector-workflows.md`:

- **A table separating the three 403s by header.** Primary zeroes `x-ratelimit-remaining`; secondary carries `retry-after` *or* only says so in the body; permission does neither. The secondary case is the trap — checking `remaining == 0` alone misfiles it as auth and aborts a run that should have waited. ([Docs](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api) say `retry-after` *may* be present, so the body is the last resort.)
- **The sibling-endpoint diagnostic.** A budget is token-wide and cannot starve one endpoint while sparing another, so `/forks` succeeding while `/stargazers` 403s disproves a rate limit in one step. That is what cracked this case.
- **The restriction itself**, with the fine-grained PAT fix (Metadata: read, which every fine-grained PAT has by default), and the token-type nuance: an Actions token gets `403`, a user PAT gets `404` where it isn't a collaborator.
- **Systemic vs per-item**, as a corollary to the existing "green build hides bad data" theme: auth failures must abort via an exception the per-item handler can't catch. Includes the empty-string trap — Actions sets a *missing* secret to `""`, so `os.environ[...]` doesn't raise and the failure is a silent 401.
- **`dawidd6/action-download-artifact`**: `branch` has no default, so it matches the latest successful run on any branch.

Two eval scenarios added (TDD): `collector_403_stargazers_restriction`, `classify_403_before_retrying`.

## Verification

Every claim was verified against the live API rather than the changelog alone:

| Claim | Evidence |
|---|---|
| Restriction is live | Collaborator PAT: 200 on `netresearch/JCarouselSlider`; 404 on `torvalds/linux`, `actions/checkout` |
| `GITHUB_TOKEN` 403s on its own repo | 278/278 repos incl. `netresearch/maint` |
| `forks` unaffected | 0 failures across the same run |
| Metadata: read suffices | Both endpoints listed under it in the permissions reference; confirmed by a working fine-grained PAT |
| The fix works | 834 → 0 API 403s, 37m4s → 9m, `Found: 0` → `Found: 34 star(s)` |

The secondary-rate-limit distinction came from a Gemini review comment on the fix PR — it caught that my first cut would have misread a secondary limit as a permission error. It's in here so the next person doesn't need the reviewer.

`markdownlint-cli2`: 0 errors. `evals.json`: valid, schema matches existing entries.