### PR TITLE
docs(ai-reviewer-pushback): gemini's version claims, and how to refute them

### DIFF
--- a/skills/github-project/references/ai-reviewer-pushback.md
+++ b/skills/github-project/references/ai-reviewer-pushback.md
@@ -41,8 +41,19 @@ The reviewer claims a current release "is not out yet," recommends an outdated m
 - "Language X version N is not released yet" — when it is. Verify against the language's release page.
 - "Use Node N as the maximum supported version" — when a newer LTS is current.
 - "Framework F version N has not been released" — when an N.x release is already in production.
+- "Tool T version vN does not exist; T is on major vN-1" — when major vN shipped after the bot's cutoff. The reply often predicts a concrete consequence ("the download will 404 and the install will silently fail") and hands you a downgrade to paste. The prediction is testable: fetch the URL and run the tool.
 
-**Tell:** version assertions without a release-date check, or recommendations that pull constraints downward from what your CI matrix is already running.
+**Tell:** version assertions without a release-date check, or recommendations that pull constraints downward from what your CI matrix is already running. A dependency- or tooling-upgrade PR is where this lands hardest — the bot's stale snapshot is, by definition, the state the PR is moving away from, so it reads every upgrade as an error.
+
+**Refuting it takes three commands** — the registry's own answer, the artifact's reachability, and the tool reporting its own version:
+
+```bash
+gh api repos/OWNER/TOOL/releases/latest --jq .tag_name          # what is actually latest
+curl -sIL -o /dev/null -w '%{http_code}\n' "$URL_THE_BOT_SAYS_404s"   # the predicted 404
+<tool> --version                                                 # the binary's own answer
+```
+
+Quote all three in the reply. A version claim refuted by the tool printing its own version number is not arguable, and it converts the thread from opinion-vs-opinion into a closed question.
 
 ### Pattern advice frozen at a past major
 
@@ -201,7 +212,7 @@ Behavior is bot-specific and changes; treat as starting hints, verify against cu
 
 | Bot | Note |
 |-----|------|
-| `gemini-code-assist[bot]` | Often confidently invents config field names; severity badges (`high`/`medium`) are not always correlated with actual severity |
+| `gemini-code-assist[bot]` | Often confidently invents config field names; **frequently behind on tool/package versions and releases** — treat every version assertion as unverified (see "Stale knowledge of release status"), especially when it asks you to pin *downward*; severity badges (`high`/`medium`) are not always correlated with actual severity |
 | `copilot-pull-request-reviewer[bot]` | Tends toward verbose summaries; reviews almost never come back as `APPROVED` (state is `COMMENTED`); see `auto-merge-guide.md` for the auto-merge race condition |
 | `coderabbitai[bot]` | Higher signal but verbose; prone to repeating the same nit across many threads — resolving in batches is reasonable |
 | `sourcery-ai[bot]` | Stylistic / refactor focus; advice quality drops on non-mainstream language constructs |

--- a/skills/github-project/references/ai-reviewer-pushback.md
+++ b/skills/github-project/references/ai-reviewer-pushback.md
@@ -48,9 +48,9 @@ The reviewer claims a current release "is not out yet," recommends an outdated m
 **Refuting it takes three commands** — the registry's own answer, the artifact's reachability, and the tool reporting its own version:
 
 ```bash
-gh api repos/OWNER/TOOL/releases/latest --jq .tag_name          # what is actually latest
+gh api repos/OWNER/TOOL/releases/latest --jq .tag_name           # what is actually latest
 curl -sIL -o /dev/null -w '%{http_code}\n' "$URL_THE_BOT_SAYS_404s"   # the predicted 404
-<tool> --version                                                 # the binary's own answer
+tool --version                                                   # the binary's own answer
 ```
 
 Quote all three in the reply. A version claim refuted by the tool printing its own version number is not arguable, and it converts the thread from opinion-vs-opinion into a closed question.
@@ -212,7 +212,7 @@ Behavior is bot-specific and changes; treat as starting hints, verify against cu
 
 | Bot | Note |
 |-----|------|
-| `gemini-code-assist[bot]` | Often confidently invents config field names; **frequently behind on tool/package versions and releases** — treat every version assertion as unverified (see "Stale knowledge of release status"), especially when it asks you to pin *downward*; severity badges (`high`/`medium`) are not always correlated with actual severity |
+| `gemini-code-assist[bot]` | Often confidently invents config field names; **frequently behind on tool/package versions and releases** — treat every version assertion as unverified (see [Stale knowledge of release status](#stale-knowledge-of-release-status)), especially when it asks you to pin *downward*; severity badges (`high`/`medium`) are not always correlated with actual severity |
 | `copilot-pull-request-reviewer[bot]` | Tends toward verbose summaries; reviews almost never come back as `APPROVED` (state is `COMMENTED`); see `auto-merge-guide.md` for the auto-merge race condition |
 | `coderabbitai[bot]` | Higher signal but verbose; prone to repeating the same nit across many threads — resolving in batches is reasonable |
 | `sourcery-ai[bot]` | Stylistic / refactor focus; advice quality drops on non-mainstream language constructs |


### PR DESCRIPTION
`ai-reviewer-pushback.md` already describes "Stale knowledge of release status" as a pattern — but the **per-bot table** only warns that `gemini-code-assist` invents config field names. A reader scanning that table gets no warning about version claims, which is the failure mode that actually costs time on dependency and tooling PRs.

## Changes

- **Per-bot table**: note that gemini is frequently behind on tool/package versions and releases — especially when it asks you to pin *downward*.
- **New shape** in the stale-release section: *"tool T version vN does not exist; T is on major vN-1"* — asserting a whole major is unreleased, packaged with a downgrade to paste.
- **Why upgrade PRs are worst**: the bot's stale snapshot is, by definition, the state the PR is moving away from — so it reads every upgrade as an error.
- **Three commands that refute it**: registry latest, the predicted-404 URL, and the tool printing its own version.

## Where this came from

netresearch/terraform-provider-ad#15 — a `golangci-lint` v1.49.0 → v2.12.2 upgrade. gemini commented, at **high** severity:

> The version `v2.12.2` for `golangci-lint` does not exist. `golangci-lint` is currently on major version `v1` (e.g., `v1.64.x`). Attempting to download from the `v2.12.2` tag on GitHub will result in a 404 error, and the installation will silently fail

…and supplied a diff pinning back to `v1.62.2`. Applying it would have silently reverted the upgrade.

All three claims were false, and each was refuted in one command:

| Claim | Reality |
|---|---|
| "v2.12.2 does not exist" | `releases/latest` → **`v2.12.2`**, published 2026-05-06 |
| "currently on major version v1" | v2 is current |
| "will result in a 404" | that exact URL → **HTTP 200** |

The installed binary settled it: `golangci-lint has version 2.12.2 built with go1.26.2`.

Confirmed by the maintainer as a recurring trait, not a one-off — hence documenting it in the per-bot table rather than leaving it as a generic pattern.

Note the second half of gemini's comment was right in principle: piping a 404 into `sh` *would* fail silently. That's a good instinct attached to a wrong fact — which is exactly why the reference tells you to verify the load-bearing claim rather than accept or dismiss wholesale.

## Verification

`markdownlint-cli2` on the changed file: **0 errors**. Docs-only, no version bump — matching the convention in `d190fb4` and the surrounding `docs(<reference>):` history.