### PR TITLE
docs(auto-merge): armed --auto may not enqueue; re-issue to enter the merge queue

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "github-project",
-  "version": "2.15.8",
+  "version": "2.15.9",
   "description": "GitHub repository setup, branch protection, and configuration",
   "repository": "https://github.com/netresearch/github-project-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",

--- a/skills/github-project/SKILL.md
+++ b/skills/github-project/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires gh CLI, git."
 metadata:
   author: Netresearch DTT GmbH
-  version: "2.15.8"
+  version: "2.15.9"
   repository: https://github.com/netresearch/github-project-skill
 allowed-tools: Bash(gh:*) Bash(git:*) Bash(grep:*) Read Write
 ---

--- a/skills/github-project/references/auto-merge-guide.md
+++ b/skills/github-project/references/auto-merge-guide.md
@@ -332,6 +332,7 @@ When landing multiple dependent PRs, expect the dependent PRs to need rebasing a
 | PR stuck after preceding PR merged | PR is now behind `main` | Rebase, force push, re-queue |
 | `REVIEW_REQUIRED` after rebase | Stale review dismissal cleared approval | Re-run auto-approve workflow |
 | Unresolved threads block merge | Old threads survive rebase | Resolve via GraphQL `resolveReviewThread` |
+| Armed (`autoMergeRequest` set) but never enters the queue | First `--auto` armed auto-merge without enqueuing — checks are green, no threads, yet `mergeQueue.entries` is empty and the PR just sits | Re-issue `gh pr merge NUMBER --auto`; it reports "already queued to merge" and the entry then shows `AWAITING_CHECKS`. Confirm with the `mergeQueue.entries` GraphQL query — do not assume arming enqueued it |
 
 ### Verifying a PR Actually Merged (enqueue ≠ merged)
 

--- a/skills/github-project/references/auto-merge-guide.md
+++ b/skills/github-project/references/auto-merge-guide.md
@@ -332,7 +332,7 @@ When landing multiple dependent PRs, expect the dependent PRs to need rebasing a
 | PR stuck after preceding PR merged | PR is now behind `main` | Rebase, force push, re-queue |
 | `REVIEW_REQUIRED` after rebase | Stale review dismissal cleared approval | Re-run auto-approve workflow |
 | Unresolved threads block merge | Old threads survive rebase | Resolve via GraphQL `resolveReviewThread` |
-| Armed (`autoMergeRequest` set) but never enters the queue | First `--auto` armed auto-merge without enqueuing — checks are green, no threads, yet `mergeQueue.entries` is empty and the PR just sits | Re-issue `gh pr merge NUMBER --auto`; it reports "already queued to merge" and the entry then shows `AWAITING_CHECKS`. Confirm with the `mergeQueue.entries` GraphQL query — do not assume arming enqueued it |
+| Armed (`autoMergeRequest` set) but never enters the queue | First `--auto` armed auto-merge without enqueuing — checks are green, no threads, yet `mergeQueue.entries` is empty and the PR just sits | Re-issue `gh pr merge NUMBER --auto`; it reports "already queued to merge" and the entry then shows `AWAITING_CHECKS`. Confirm with the [`mergeQueue.entries` GraphQL query](#verifying-a-pr-actually-merged-enqueue--merged) — do not assume arming enqueued it |
 
 ### Verifying a PR Actually Merged (enqueue ≠ merged)
 


### PR DESCRIPTION
From a retrospective on a live multi-PR session.

On a merge-queue repo, the first `gh pr merge NUMBER --auto` occasionally arms auto-merge (`autoMergeRequest` set) **without** actually enqueuing the PR — all checks green, no unresolved threads, but `mergeQueue.entries` is empty and the PR sits indefinitely. Re-issuing the same `gh pr merge --auto` reports "already queued to merge" and the entry then shows `AWAITING_CHECKS`.

Adds one row to the Merge Queue troubleshooting table so this is fixed by an active nudge + `mergeQueue.entries` verification, rather than rediscovered as passive waiting. Distinct from the existing "enqueue ≠ merged" note (that's about not reporting merged off the exit code; this is about the arm not enqueuing at all).

Skill 2.15.8 → 2.15.9. Docs-only.