### PR TITLE
docs(reusable-workflows): make pitfall #6 fire when editing a consumer workflow

### DIFF
--- a/skills/github-project/SKILL.md
+++ b/skills/github-project/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: github-project
-description: "Use when bootstrapping a repo (apply branch protection before first PR), PRs won't merge or BLOCKED, AI reviewer pushback, auto-merge fails for Dependabot/Renovate, branch protection or rulesets, CI fails, authoring reusable workflows, harden-runner, or CODEOWNERS/PR templates."
+description: "Use when bootstrapping a repo (apply branch protection before first PR), PRs won't merge or BLOCKED, AI reviewer pushback, auto-merge fails for Dependabot/Renovate, branch protection or rulesets, CI fails, authoring or consuming reusable workflows, editing a repo's own .github/workflows, harden-runner, or CODEOWNERS/PR templates."
 license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires gh CLI, git."
 metadata:
@@ -14,7 +14,8 @@ allowed-tools: Bash(gh:*) Bash(git:*) Bash(grep:*) Read Write
 
 ## When to Use
 
-- **Post `gh repo create` + initial push, before first PR** — apply branch protection (REQUIRED, see below)
+- **Post `gh repo create`, before first PR** — REQUIRED: `scripts/init-branch-protection.sh OWNER/REPO` (`references/repo-bootstrap.md`)
+- Adding a job to a repo's workflow — see pitfall #6
 - PR won't merge / threads
 - Auto-merge fails (Dependabot/Renovate)
 - Solo auto-approve
@@ -25,8 +26,6 @@ allowed-tools: Bash(gh:*) Bash(git:*) Bash(grep:*) Read Write
 - Scorecard
 - CODEOWNERS, templates, labels
 - Fork PR merge base
-
-> **REQUIRED post `gh repo create`:** `scripts/init-branch-protection.sh OWNER/REPO` — see `references/repo-bootstrap.md`.
 
 ## Quick Diagnostics
 
@@ -72,7 +71,7 @@ gh pr view PR --repo OWNER/REPO --json reviewThreads --jq '.reviewThreads'
 
 ### Merge Strategy Issues
 
-See `references/auto-merge-guide.md` (signed-commit rebase fixes, workflow-file PRs, Copilot auto-approve race).
+See `references/auto-merge-guide.md` (signed-commit rebase, workflow-file PRs, Copilot race).
 
 ## Running Scripts
 
@@ -84,7 +83,7 @@ scripts/verify-github-project.sh /path/to/repository      # local-checkout audit
 
 ## No editorializing
 
-State what a change does, not how good it is; no self-praise. See `references/no-editorializing.md`.
+State what a change does, not how good it is. See `references/no-editorializing.md`.
 
 ## References
 

--- a/skills/github-project/SKILL.md
+++ b/skills/github-project/SKILL.md
@@ -14,7 +14,7 @@ allowed-tools: Bash(gh:*) Bash(git:*) Bash(grep:*) Read Write
 
 ## When to Use
 
-- **Post `gh repo create`, before first PR** — REQUIRED: `scripts/init-branch-protection.sh OWNER/REPO` (`references/repo-bootstrap.md`)
+- **Post `gh repo create` + push, before first PR** — REQUIRED: `scripts/init-branch-protection.sh OWNER/REPO` (`references/repo-bootstrap.md`)
 - Adding a job to a repo's workflow — see pitfall #6
 - PR won't merge / threads
 - Auto-merge fails (Dependabot/Renovate)

--- a/skills/github-project/references/reusable-workflow-pitfalls.md
+++ b/skills/github-project/references/reusable-workflow-pitfalls.md
@@ -103,6 +103,42 @@ Before adding a guard, check, or fix to a project's own workflow files, ask whet
 
 This is distinct from pitfalls #1–#5 above (which cover *how* to author and reference reusable workflows) — this is about *where* a fix belongs.
 
+### The consumer-side tell
+
+The rule is easiest to apply as a property of the consumer's workflow file: **every job in a
+consumer repo is a `uses:` of a shared workflow.** A job with its own `steps:` — checkout,
+setup, install, run — is the smell, and third-party actions (`actions/checkout`,
+`shivammathur/setup-php`, …) appearing anywhere outside the shared-workflow repo is the same
+smell stated in terms of `uses:`. Verify with:
+
+```bash
+grep -rn "uses:" .github/workflows/ | grep -v "YOUR_ORG/"
+```
+
+Anything that returns is either a genuinely project-specific exception or work that belongs
+upstream. Pinning such an action to a SHA does not make it compliant — the pin is a separate
+requirement (`reusable-workflow-security.md`), not a substitute for this one.
+
+### Extending the shared workflow instead
+
+When the shared workflow has no input for what the consumer needs, add one — this is the
+supported path, not a workaround:
+
+- Add the input **defaulting to off** (`type: boolean`, `default: false`) and gate the new
+  job on it, so every existing consumer is unaffected. Verify the diff is purely additive
+  (`git diff -U0 | grep -E '^-[^-]'` returns nothing) — an existing consumer must not change
+  behaviour because another repo needed a feature.
+- Copy the action pins verbatim from a neighbouring job in the same file rather than picking
+  versions independently; a shared workflow with two different `actions/checkout` SHAs is its
+  own maintenance problem.
+- Give the new job a graceful skip (a `::notice::`) when the consumer lacks the underlying
+  script, so enabling the input in a repo that is not ready cannot hard-fail.
+- Land it, then flip the input on in the consumer. The consumer's change is one line.
+
+Do not reach for `unit-test-command`-style override inputs to smuggle an extra suite into an
+existing job: those replace the job's instrumented default command and silently drop whatever
+it did (coverage upload, for instance).
+
 ## 7. Run with zero jobs whose name is the file path = workflow-validation failure
 
 A run with `conclusion: startup_failure` (or `failure`), **zero jobs**, and a displayed name that falls back to the workflow **file path** failed at workflow *validation*, before any job started. The exact reason is **only in the Actions UI banner** — it is not exposed via the REST API (`gh run view --log[-failed]` returns "log not found"; run/annotations/check-suite endpoints are empty). If you can't see the UI, ask for the banner text. Two causes seen in practice:

--- a/skills/github-project/references/reusable-workflow-pitfalls.md
+++ b/skills/github-project/references/reusable-workflow-pitfalls.md
@@ -112,7 +112,7 @@ setup, install, run — is the smell, and third-party actions (`actions/checkout
 smell stated in terms of `uses:`. Verify with:
 
 ```bash
-grep -rn "uses:" .github/workflows/ | grep -v "YOUR_ORG/"
+grep -rn "uses:" .github/workflows/ | grep -vi "YOUR_ORG/"
 ```
 
 Anything that returns is either a genuinely project-specific exception or work that belongs
@@ -126,7 +126,7 @@ supported path, not a workaround:
 
 - Add the input **defaulting to off** (`type: boolean`, `default: false`) and gate the new
   job on it, so every existing consumer is unaffected. Verify the diff is purely additive
-  (`git diff -U0 | grep -E '^-[^-]'` returns nothing) — an existing consumer must not change
+  (`git diff origin/main... -U0 | grep -E '^-[^-]'` returns nothing) — an existing consumer must not change
   behaviour because another repo needed a feature.
 - Copy the action pins verbatim from a neighbouring job in the same file rather than picking
   versions independently; a shared workflow with two different `actions/checkout` SHAs is its


### PR DESCRIPTION
## Came from

`/retro` on a session working two TYPO3 extension PRs (netresearch/t3x-nr-image-optimize#115 / #116).

This is a **C4** finding — the guidance existed and did not hold. Pitfall #6, added by an earlier `/retro` in #82, already says a CI gap belongs upstream in the shared workflow rather than in the consumer. I nonetheless added a local `acceptance` job with its own `actions/checkout` and `shivammathur/setup-php` to **both** consumer repos, and the maintainer had to correct it — then had to correct it a second time when I asked whether to SHA-pin a third-party action seconds after being told we don't use them.

## Why it didn't fire

**The skill was never loaded.** The `description` said *"authoring reusable workflows"*, which reads as authoring the shared workflow — not as editing a consumer's `.github/workflows`. That is the case I was in, and no trigger word covered it.

**The pitfall stated a principle without a test for it.** "Ask whether the shared repo owns that concern" needs judgement at exactly the moment you have already decided to write the job. A mechanical tell is easier to obey.

## Change

- `SKILL.md` — `description` covers *consuming* reusable workflows and editing a repo's own `.github/workflows`; a `When to Use` entry points at pitfall #6. The file is at the 500-word limit, so this is paid for by folding the duplicated branch-protection note (it appeared both as a list item and as a standalone blockquote) into its list entry. **497 words** after the change, verified with `wc -w`.
- `references/reusable-workflow-pitfalls.md` — pitfall #6 gains:
  - **the consumer-side tell** — every job in a consumer is a `uses:` of a shared workflow, so a job with its own `steps:`, or any non-org action, is the smell; with a grep that checks it. Notes that SHA-pinning such an action does not make it compliant.
  - **the upstream mechanics** — additive input defaulting to `false`, purely-additive diff check, pins copied verbatim from a neighbouring job, graceful skip for consumers without the underlying script, then a one-line flip in the consumer.
  - a warning against `unit-test-command`-style override inputs, which replace the job's instrumented default and silently drop what it did (in that session, the Codecov upload).

The upstream path described here is the one that ended up being taken: netresearch/typo3-ci-workflows#136 added a `run-acceptance-tests` input defaulting to `false` (113 insertions, 0 deletions), and both consumers then enabled it with one line.

## Test plan

- [x] pre-commit hooks incl. `markdownlint-cli2`, skill-structure validation and version parity — passed
- [x] `wc -w skills/github-project/SKILL.md` → 497 (cap 500)
