### PR TITLE
docs(gh-cli): do not tail a failed job log on harden-runner repos

### DIFF
--- a/skills/github-project/references/gh-cli-reference.md
+++ b/skills/github-project/references/gh-cli-reference.md
@@ -59,7 +59,6 @@ Rapid sequences of `gh api` calls (REST + GraphQL) sometimes return `401 "Requir
   ```
   The lines above the marker carry the actual cause (the failing command's own output); the marker line itself is often just `Process completed with exit code 1`.
 
-
 - **A bare status code matches things that are not errors.** `grep -c 403` over a job log also hits commit SHAs, ref names and git plumbing output in the `Checkout` step. A real case: a fixed run still showed 8 hits for `403` — all from `Checkout`, none an API error — which reads as "still broken". Match the error *text* (`Client Error: Forbidden`), and scope the count to the step that makes the calls.
 
   Each line is `<job>\t<step>\t<timestamp> <text>`, so anchor the step to the start of the line — an unanchored step name also matches log *prose* that mentions it:

--- a/skills/github-project/references/gh-cli-reference.md
+++ b/skills/github-project/references/gh-cli-reference.md
@@ -50,7 +50,15 @@ Rapid sequences of `gh api` calls (REST + GraphQL) sometimes return `401 "Requir
 
 ### Reading a run's log: grep the error text, not the status code
 
-`gh run view --job=<id> --log` prefixes every line with the step name. Two traps when you count errors in it:
+`gh run view --job=<id> --log` prefixes every line with the step name. Three traps when you read errors in it:
+
+- **`--log-failed | tail` shows the wrong end of the log.** On a repo running `step-security/harden-runner`, the post-job step appends its egress-audit dump — DNS resolutions, `sudo` calls, the full `agent.service` journal — *after* the step that failed. Tailing a failed job therefore returns pages of runner telemetry and none of the error. Redirect to a file and grep for the annotation marker instead:
+  ```bash
+  gh run view <RUN_ID> --repo OWNER/REPO --log-failed > run.log
+  grep -nE '##\[error\]' run.log      # then read the ~20 lines above each hit
+  ```
+  The lines above the marker carry the actual cause (the failing command's own output); the marker line itself is often just `Process completed with exit code 1`.
+
 
 - **A bare status code matches things that are not errors.** `grep -c 403` over a job log also hits commit SHAs, ref names and git plumbing output in the `Checkout` step. A real case: a fixed run still showed 8 hits for `403` — all from `Checkout`, none an API error — which reads as "still broken". Match the error *text* (`Client Error: Forbidden`), and scope the count to the step that makes the calls.
 


### PR DESCRIPTION
## Summary

`gh run view --log-failed | tail` returns harden-runner's post-job egress dump rather than the failure, because that step runs after the one that failed.

## Came from

`/retro` session on 2026-07-25.
Finding: B16 (hard-won technique).

- **Symptom:** Two reads of two failing jobs returned only StepSecurity telemetry — DNS resolutions, `sudo` calls, the `agent.service` journal — and no error text.
- **Cause:** `step-security/harden-runner`'s post-job step appends its audit output after the failing step, so the tail of a failed job is runner telemetry.
- **Required behavior:** Redirect `--log-failed` to a file and `grep -nE '##\[error\]'`, then read the lines above each hit — the marker line itself is usually just `Process completed with exit code N`.
- **Verification:** Both errors in this session (`Your lock file does not contain a compatible set of packages`, the `composer audit` advisory table) were found by the grep after the tails showed nothing.

## Change

`references/gh-cli-reference.md`: third trap in the existing "Reading a run's log" section.

## Test plan

- [x] `scripts/verify-harness.sh` — Level 3 COMPLETE, 0 errors
- [x] Recipe run as written against runs 30163820115 / 30163820120
