### PR TITLE
docs: post-merge CI gap after auto-merge, and fork-deletion safety

### DIFF
--- a/skills/github-project/references/auto-merge-guide.md
+++ b/skills/github-project/references/auto-merge-guide.md
@@ -574,3 +574,73 @@ gh api repos/OWNER/REPO/branches/main/protection/required_pull_request_reviews -
 }
 EOF
 ```
+
+## Auto-merged PRs leave the base branch without post-merge CI
+
+A merge performed with `GITHUB_TOKEN` — which is what the auto-merge workflow
+uses, directly or via `gh pr merge --auto` — does not trigger further workflow
+runs. GitHub suppresses workflow triggers for events created by that token, so
+the `push` to the base branch produces nothing. Measured on one repository:
+
+| Merge commit | Merged by | push-triggered CI runs on `main` |
+|---|---|---|
+| `699df245` | maintainer (`gh pr merge`) | 5 |
+| `162c57b7` | maintainer (`gh pr merge`) | 5 |
+| `ddc3810a` | auto-merge workflow | **0** |
+| `5a513fe1` | auto-merge workflow | **0** |
+| `875fb1a4` | auto-merge workflow | **0** |
+| `c61d560f` | auto-merge workflow | **0** |
+
+Rule out the cheaper explanation first — a `paths`/`paths-ignore` filter on the
+`push` trigger produces the same symptom:
+
+```bash
+gh api repos/$R/contents/.github/workflows/ci.yml --jq .content | base64 -d | yq '.on'
+```
+
+On its own the missing run is tolerable, because the PR's own CI covered the
+head commit. It becomes a hole when combined with a non-strict status-check
+policy: the PR may have been tested against a `main` that has since advanced,
+and nothing ever tests the combination.
+
+```bash
+gh api repos/$R/rules/branches/main \
+  --jq '.[]|select(.type=="required_status_checks")|.parameters'
+# strict_required_status_checks_policy: false  →  stale PRs may merge untested
+```
+
+Two fixes, in increasing strength:
+
+1. **`strict_required_status_checks_policy: true`** — one flag. GitHub holds the
+   merge until the branch is current, so the tested tree equals the merged tree
+   and the missing post-merge run stops mattering. Cost: every base-branch push
+   invalidates open PRs, which then need an update (`allow_update_branch: true`
+   and the bots handle their own). Reversible with one API call — back the
+   ruleset up first (`gh api repos/$R/rulesets/$ID > backup.json`).
+2. **Merge queue** — tests the merge *result* before it lands, and covers
+   maintainer merges too. Needs a `merge_group:` trigger in the CI workflow and
+   queue configuration in the ruleset.
+
+Do **not** try to bolt a post-merge `workflow run` dispatch onto the auto-merge
+job. `workflow_dispatch` and `repository_dispatch` are indeed the documented
+exceptions to the `GITHUB_TOKEN` suppression, but when the base branch has
+required checks the job takes the native path — `gh pr merge --auto` followed by
+`exit 0` — and finishes long before GitHub performs the merge. There is no point
+in that job at which the merge commit exists.
+
+## Auto-merge can land a bot PR while you are still fixing it
+
+In a repo with an auto-merge deps workflow, pushing a fix to a bot PR's branch
+starts a clock: as soon as the required checks go green the workflow merges,
+with no further confirmation. Two dependency PRs merged four minutes apart while
+a correction to one of them was still being verified locally — the flawed commit
+reached the base branch and needed a follow-up PR instead of an amend.
+
+Treat "pushed and green" as "merged" on those branches:
+
+- Finish verification *before* the push that turns the PR green, not after.
+- Once it is green, plan on a follow-up PR against the base branch. Amending and
+  force-pushing races the workflow and fails with `stale info` once the branch
+  is deleted post-merge.
+- Check whether the merge already happened before diagnosing a push failure:
+  `gh pr view $PR --repo $R --json state,mergedAt,mergedBy`.

--- a/skills/github-project/references/multi-repo-operations.md
+++ b/skills/github-project/references/multi-repo-operations.md
@@ -60,6 +60,51 @@ Never enable auto-merge on archived repos — the auto-merge plumbing fails at s
 
 **Safer default for batch file edits**: open a one-commit PR per repo even when the Contents API would work. Gives you a reviewable diff, matches any future signing/protection rule tightening, and keeps behavior consistent across the fleet.
 
+### 4. Forks: "0 ahead" on the default branch does not mean "dead"
+
+Fleet cleanups and advisory sweeps both reach the same question — is this fork
+still needed, or can it go? The usual check compares the *default* branch:
+
+```bash
+gh api "repos/$UPSTREAM/compare/$DEFAULT...${OWNER}:$DEFAULT" --jq '.ahead_by'
+```
+
+`ahead_by: 0` plus no open upstream PRs reads as a pure mirror with nothing to
+lose. It is not sufficient. One fork that reported `0 ahead / 1 behind` on
+`master`, with issues disabled, no releases, no stars and no upstream PRs, held
+**26 commits across 8 non-default branches** — `task/build-setup` (9),
+`bugfix/sticky-header-scroll-flicker` (8), `task/simplify-tca` (4) and five more
+at 1 each. Deleting it would have destroyed all of them.
+
+Enumerate every branch before deleting or archiving a fork:
+
+```bash
+UPSTREAM=upstream-owner/repo; FORK=our-org/repo; DEFAULT=$(gh api "repos/$UPSTREAM" --jq .default_branch)
+for b in $(gh api "repos/$FORK/branches" --paginate --jq '.[].name'); do
+  n=$(gh api "repos/$UPSTREAM/compare/$DEFAULT...${FORK%%/*}:$b" --jq '.ahead_by' 2>/dev/null)
+  [ "${n:-0}" -gt 0 ] && echo "$b ahead=$n"
+done
+```
+
+Any non-zero result is unmerged local work: land it upstream or preserve it
+before the repo goes. Note that `open_issues_count` includes PRs, so a fork with
+issues disabled can still report `1` — resolve what it is rather than assuming.
+
+When the goal was only to clear the fork's Dependabot alerts, prefer dismissing
+them over deleting the repo. A fork's lockfile belongs to upstream; patching it
+diverges the fork without removing exposure that a never-built fork does not
+have.
+
+```bash
+gh api -X PATCH "repos/$FORK/dependabot/alerts/$N" \
+  -f state=dismissed -f dismissed_reason=not_used \
+  -f dismissed_comment="$COMMENT"   # 280 chars max, or HTTP 422
+```
+
+Say *why* in the comment — that the lockfile is upstream's, that upstream is
+still on the vulnerable version, and that the fork is never built or deployed.
+"not_used" alone tells the next reader nothing.
+
 ## Parallel PR Rebasing
 
 For N PRs that need rebasing on their default branches, dispatch parallel subagents — one per PR — with failure isolation.


### PR DESCRIPTION
From a `/retro` sweep of a dependency-maintenance session across several org repos. Two findings, two commits.

## `auto-merge-guide.md` — post-merge CI gap, and the race with in-flight fixes

A merge performed with `GITHUB_TOKEN` does not trigger further workflow runs, so an auto-merged PR leaves the base branch with **no** push-triggered CI. Measured across six merge commits in one repo:

| Merged by | push-triggered CI runs on `main` |
|---|---|
| maintainer (`gh pr merge`), 2 commits | 5 each |
| auto-merge workflow, 4 commits | **0** |

On its own that is tolerable — the PR's own CI covered its head. It becomes a hole together with `strict_required_status_checks_policy: false`: the PR may have been tested against a `main` that has since advanced, and nothing ever tests the combination. The first verification is then the nightly schedule, which is how a red `main` surfaced hours after the merge in this session.

The section documents ruling out a `paths` filter first, the two fixes in increasing strength (strict policy — one reversible flag; merge queue — tests the merge result and covers maintainer merges too), and why a post-merge `workflow run` dispatch **cannot** be bolted onto the auto-merge job: `workflow_dispatch` is indeed exempt from the suppression, but with required checks the job takes the native `gh pr merge --auto` path and exits before GitHub performs the merge.

Second section: pushing a fix to a bot PR's branch starts a clock. Two dependency PRs merged four minutes apart while a correction to one was still being verified locally; the flawed commit reached `main` and needed a follow-up PR instead of an amend.

## `multi-repo-operations.md` — check every branch before deleting a fork

Comparing only the default branch is not sufficient to call a fork dead. A fork reporting `0 ahead / 1 behind` on `master`, with issues disabled, no releases, no stars and no upstream PRs, held **26 commits across 8 non-default branches**. Deleting it — which had already been approved on the strength of the default-branch comparison — would have destroyed them.

Adds the per-branch comparison loop, notes that `open_issues_count` includes PRs (so a fork with issues disabled can still report `1`), and points at dismissing the fork's Dependabot alerts as `not_used` instead of deleting: a fork's lockfile belongs to upstream, and patching it diverges the fork without removing exposure a never-built fork does not have. Includes the 280-char `dismissed_comment` limit and what the comment should actually say.

## Verification

`scripts/verify-harness.sh` — Level 3 COMPLETE, 0 errors, 0 warnings.
