### PR TITLE
docs(github-project): two checks that pass while measuring nothing

### DIFF
--- a/skills/github-project/references/reusable-workflow-pitfalls.md
+++ b/skills/github-project/references/reusable-workflow-pitfalls.md
@@ -149,3 +149,55 @@ A run with `conclusion: startup_failure` (or `failure`), **zero jobs**, and a di
 ```bash
 gh api repos/O/R/actions/permissions --jq '.default_workflow_permissions? // ""'   # reveals a restrictive 'read' default
 ```
+
+
+## 8. `release: published` never fires for a release a workflow created
+
+A workflow that reacts to releases with
+
+```yaml
+on:
+  release:
+    types: [published]
+```
+
+is **inert for every automated release**. GitHub does not raise events from
+actions taken with the default `GITHUB_TOKEN` — a deliberate guard against
+recursive runs — and the release is created by the release workflow using
+exactly that token. The trigger only fires for releases a human creates in the
+UI or via a PAT.
+
+This fails silently in the worst way: the workflow is registered, `state:
+active`, and simply never runs. Nothing appears in the Actions tab to explain
+the absence.
+
+Trigger off the producing workflow instead:
+
+```yaml
+on:
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
+
+jobs:
+  verify:
+    # A run that failed has nothing to verify, and head_branch is only a tag
+    # when the run came from a tag push.
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      startsWith(github.event.workflow_run.head_branch, 'v')
+```
+
+`workflow_run` observes the run regardless of which token created what.
+
+**A repo's history can mislead you here.** Checking for past `event=release`
+runs is not evidence the trigger works today: a repo that once created releases
+by hand will show dozens of them, all predating the automation.
+
+### Corollary: test the trigger you ship, not a convenient one
+
+Adding `workflow_dispatch` alongside the real trigger makes the workflow easy to
+exercise — and a dispatch run proves only that the *jobs* work. It says nothing
+about whether the event you actually depend on ever arrives. A gate can pass its
+manual test and still be dead in production. If the real trigger cannot be
+exercised before merge, say so rather than treating the dispatch run as proof.

--- a/skills/github-project/references/reusable-workflow-pitfalls.md
+++ b/skills/github-project/references/reusable-workflow-pitfalls.md
@@ -188,7 +188,16 @@ jobs:
       startsWith(github.event.workflow_run.head_branch, 'v')
 ```
 
-`workflow_run` observes the run regardless of which token created what.
+`workflow_run` observes a workflow *run*, not a repository event, so the
+GITHUB_TOKEN suppression does not apply to it.
+
+Two constraints come with it:
+
+- The workflow file must be on the **default branch**. A `workflow_run`
+  trigger added on a feature branch does nothing until it is merged — so it
+  cannot be exercised on the PR that introduces it.
+- **`workflow_run` does not chain.** A workflow started by `workflow_run`
+  cannot itself trigger another one.
 
 **A repo's history can mislead you here.** Checking for past `event=release`
 runs is not evidence the trigger works today: a repo that once created releases

--- a/skills/github-project/references/security-config.md
+++ b/skills/github-project/references/security-config.md
@@ -330,6 +330,57 @@ gh api repos/OWNER/REPO/check-runs/CHECK_RUN_ID/annotations \
 | 4 | All review threads resolved | GraphQL reviewThreads query |
 | 5 | Branch rebased on target | `gh pr view NUMBER --json mergeStateStatus` is `CLEAN` |
 
+## Secret Scanning: A Config File Replaces the Ruleset
+
+gitleaks does **not** merge your config with its built-in rules. A
+`.gitleaks.toml` that declares only an allowlist declares *no rules at all*, and
+the scan then matches nothing — reporting `no leaks found` for every input,
+including a live credential sitting in the diff.
+
+```toml
+# Without this block, everything below replaces the defaults
+# instead of extending them.
+[extend]
+useDefault = true
+
+[allowlist]
+paths = ['''testdata/''']
+```
+
+The failure is invisible by construction: a scanner that finds nothing looks
+exactly like a clean repository. A green secret-scanning check is therefore not
+evidence of anything until you have seen it fail once.
+
+**Verify by planting one.** Write a value matching a rule you expect to fire
+into a scratch file **outside the repository** and confirm the scan reports it:
+
+```bash
+# Assemble the probe so no secret-shaped literal is ever committed.
+printf 'token = "%s-1234567890-abcdefghijklmnopqrstuvwx"\n' 'xoxb' \
+  > /tmp/leak-probe.txt
+gitleaks dir /tmp --no-banner        # expect: leaks found: 1
+```
+
+Keep the probe out of the repository, and out of the documentation too:
+GitHub's push protection scans what you push and will **block a commit that
+merely documents a realistic-looking token** — including a page explaining how
+to test secret scanning. The block is correct behaviour; work around it by
+assembling the value at runtime rather than by requesting an exemption.
+
+Three traps when testing:
+
+- **Well-known example credentials are allowlisted upstream.** AWS's
+  `AKIAIOSFODNN7EXAMPLE` and friends will not be reported no matter what.
+  Use a value that is not in anyone's allowlist.
+- **gitleaks auto-discovers a config in the scanned directory.** Copying the
+  repo's `.gitleaks.toml` next to the probe file silently re-applies the config
+  you were trying to test without.
+
+Also distinguish the two scan modes: `gitleaks dir` scans the working tree,
+`gitleaks git` scans history. A repo can be clean on disk and still carry a
+credential in a commit from months ago — and replacing the file does not remove
+it from history, so a leaked credential still needs rotating.
+
 ## OpenSSF Scorecard Quick Reference
 
 If your Scorecard score is low, check these common issues:


### PR DESCRIPTION
Both from the same release sweep, both the same shape: a control that looks wired up and reports success without doing anything.

## `release: published` never fires for an automated release

Added as pitfall 8 in `reusable-workflow-pitfalls.md`. GitHub raises no events from the default `GITHUB_TOKEN`, and the release is created by the release workflow using exactly that token — so a `release` trigger is inert for every release the project actually produces. The workflow registers as `state: active` and never runs; nothing in the Actions tab explains the absence.

I shipped and merged such a gate. It was caught only when the next real release produced no verification run.

Two things worth having written down: **repo history misleads here** — the repo had 47 past `event=release` runs, all from an era of hand-created releases, which is exactly the evidence that makes the trigger look fine. And the corollary: **a `workflow_dispatch` test exercises the jobs, not the event.** My manual test passed while the shipped trigger was dead.

## A gitleaks config replaces the ruleset instead of extending it

Added to `security-config.md`. Without `[extend] useDefault = true`, a `.gitleaks.toml` declaring only an allowlist declares *no rules*, and every scan reports `no leaks found` — for any input. Verified by A/B: the same file with the block reports a planted token, without it reports nothing.

The section lists three traps, the third found while writing this PR:

1. Well-known example credentials such as `AKIAIOSFODNN7EXAMPLE` are allowlisted upstream and will never be reported.
2. gitleaks auto-discovers a config in the scanned directory, so copying the repo's config next to the probe silently re-applies the thing you were testing without.
3. **GitHub push protection blocks a commit that merely documents a realistic-looking token** — it rejected the first version of this very PR. The example now assembles the value at runtime instead. Working around it by requesting a secret-scanning exemption would have been the wrong move: the protection was doing its job.