### PR TITLE
docs(references): signed-commits/DCO enforcement + reusable pitfalls/security

### DIFF
--- a/skills/github-project/references/dependency-management.md
+++ b/skills/github-project/references/dependency-management.md
@@ -640,3 +640,28 @@ PRs modifying workflow files require manual merge by a repository admin.
 ```
 
 The lockfile `name` then stays stable regardless of which worktree folder you run `npm install` in. This bites specifically in git worktree workflows; a plain clone (dir == repo name) masks it.
+
+## Enforcing Signed Commits + DCO Without Blocking the Bots
+
+Requiring **signed commits** (`required_signatures`) and/or **DCO sign-off** across repos collides head-on with dependency automation, because bot commits are typically **unsigned** and carry **no `Signed-off-by`**:
+
+- `required_signatures` has **no bot exemption** — it applies to every commit. Renovate commits pushed over git are unverified; Dependabot commits are *inconsistently* signed (some `verification.verified=true`, some `unsigned` in the same org). So turning it on blocks those PRs.
+- DCO requires a `Signed-off-by` trailer bots don't add — a naive DCO gate blocks **every** Dependabot/Renovate PR.
+
+Verify the blast radius before flipping anything on:
+
+```bash
+# Are bot commits signed?
+gh api "repos/OWNER/REPO/commits?per_page=40" \
+  --jq '[.[]|select(.commit.author.name|test("dependabot|renovate";"i"))][0]
+        | {verified:.commit.verification.verified, signoff:(.commit.message|test("Signed-off-by"))}'
+```
+
+**A working recipe (per repo — GitHub Free has no org-level rulesets, so there is no org-wide shortcut):**
+
+1. **Make Renovate sign.** Set `platformCommit: enabled` in the shared Renovate preset (or repo config). Renovate then creates commits through the GitHub API, which GitHub signs → `verified`.
+2. **Drop Dependabot** where signatures are required — it can't be made to sign reliably. Standardise on Renovate (which now signs). This also ends the double-manager problem if both were configured.
+3. **Exempt bots from DCO**, not from signatures. A reusable DCO check with a bot-login allowlist (`dependabot[bot],renovate[bot],github-actions[bot]`) lets bot PRs pass while still requiring humans to `git commit -s`. (Bots stay unsigned-off but are allowlisted; they are *signed* via step 1.)
+4. **Enforce.** `required_signatures` via classic protection `POST repos/OWNER/REPO/branches/main/protection/required_signatures`, or — on repos with **no classic protection** (rulesets only) — a ruleset rule `{"type":"required_signatures"}`. Add the DCO check as a required context the same way (classic `required_status_checks` or a `required_status_checks` ruleset rule).
+
+Note the classic `PATCH …/required_status_checks` **404s** ("Required status checks not enabled") when that component isn't already configured — add the check via a ruleset instead, which works regardless of classic protection.

--- a/skills/github-project/references/reusable-workflow-pitfalls.md
+++ b/skills/github-project/references/reusable-workflow-pitfalls.md
@@ -210,3 +210,37 @@ exercise — and a dispatch run proves only that the *jobs* work. It says nothin
 about whether the event you actually depend on ever arrives. A gate can pass its
 manual test and still be dead in production. If the real trigger cannot be
 exercised before merge, say so rather than treating the dispatch run as proof.
+
+## 9. Converting an inline job to a reusable call renames its check → update the required contexts
+
+When you replace an inline job with a `uses:` reusable-workflow call, the surfaced
+check name changes from `<job-id>` to **`<caller-job-id> / <reusable-job-name>`**.
+Example: an inline `build:` job reported as `build`; after routing it through
+`build-container-bake.yml` it reports as `build / Build Container (Bake)`.
+
+Any branch-protection **required status check** or **merge-queue ruleset** that
+still lists the *old* context (`build`) now waits on a check that will never
+report — the PR sits `BLOCKED` / the merge-group is ejected, forever, even though
+every visible check is green.
+
+**Fix:** the required-context list must be migrated alongside the workflow change.
+Because the exact new name isn't always predictable, observe it on the first run,
+then update the gate:
+
+```bash
+# 1. New context name from the PR's first run
+gh pr checks <PR> --repo OWNER/REPO | grep -i build
+
+# 2a. Classic protection — preserve the other contexts, swap the renamed one
+gh api repos/OWNER/REPO/branches/main/protection/required_status_checks \
+  --jq '.contexts'                       # read current
+# PATCH back with the old name replaced by "build / Build Container (Bake)"
+
+# 2b. Merge-queue / ruleset — edit the ruleset's required_status_checks rule
+gh api repos/OWNER/REPO/rulesets/<id>    # find the required_status_checks rule
+# PUT the ruleset back with the context renamed
+```
+
+Do this in lockstep with merging the workflow PR, or the repo is unmergeable
+until someone notices. (See also `dependency-management.md` for enabling a
+required check via a ruleset when classic `required_status_checks` isn't set.)

--- a/skills/github-project/references/reusable-workflow-security.md
+++ b/skills/github-project/references/reusable-workflow-security.md
@@ -274,3 +274,30 @@ PR never touched. To read them, list the analyses via
 newest analysis `id`, then fetch that analysis's SARIF —
 `gh api repos/OWNER/REPO/code-scanning/analyses/<id> -H 'Accept: application/sarif+json'`
 — and inspect the result locations. Fix the reusable workflow, not the innocent PR.
+
+## Some things should not be a reusable — the security gates are telling you
+
+Before wrapping an action in a shared workflow, ask whether the wrapper *fights*
+the org's own scanners. Two patterns that surfaced against zizmor + CodeQL:
+
+**A reusable that runs a caller-supplied script.** A generic "ssh-deploy" that
+executes `inputs.script` on a remote host is flagged by both zizmor
+(*template-injection*) and CodeQL (*code injection*) — **by design**, because a
+reusable input is attacker-influenceable if a caller ever wires it to an
+untrusted trigger. Routing the script through `env:` (`env.X`) silences zizmor
+but **not** CodeQL, which still traces `env.X ← inputs.script`. The gate is
+correct: a run-arbitrary-caller-code leaf is exactly what the injection rules
+exist to prevent. If the value the reusable adds is only "centralise one
+infrequently-bumped action," the honest call is often to **keep the single
+pinned action inline** as a documented exception rather than suppress security
+alerts on a production-deploy reusable.
+
+**Prefer the runner's `gh` CLI over wrapping a third-party release action.**
+zizmor flags `softprops/action-gh-release` with *"action functionality is
+already included by the runner: use `gh release` in a script step."* Rewriting
+the reusable to `gh release create`/`edit` (with the notes body passed through
+`env` and written via `--notes-file`) is both zizmor- and CodeQL-clean **and**
+leaves **zero external actions** in the chain — the ideal end state for an
+"actions live only in shared workflows" policy. General rule: if the runner
+already ships a CLI that does the job (`gh`, `docker`, `cosign`), a reusable
+built on that CLI beats one that pins yet another third-party action.


### PR DESCRIPTION
Captures three reusable learnings from a large GitHub CI-centralization + signature/DCO-governance session:

1. **dependency-management.md** — enforcing `required_signatures` + DCO across repos without blocking dependency bots (the blast radius, and the working recipe: Renovate `platformCommit`, drop Dependabot, DCO bot-exemption, per-repo enforcement since GitHub Free has no org rulesets).
2. **reusable-workflow-pitfalls.md** — new pitfall #9: converting an inline job to a reusable-workflow call renames its check context (`build` → `build / <reusable-job>`), which silently breaks any branch-protection/merge-queue required check listing the old name.
3. **reusable-workflow-security.md** — when the org's own zizmor/CodeQL reject a reusable (caller-supplied script = injection by design), that's a signal not to build it; and prefer the runner's `gh` CLI over wrapping a third-party release action (zero external actions).