### PR TITLE
docs: point secret-scanning guidance at betterleaks

### DIFF
--- a/skills/github-project/references/auto-merge-guide.md
+++ b/skills/github-project/references/auto-merge-guide.md
@@ -47,7 +47,7 @@ EOF
 | "Merge method X not allowed" | Wrong merge strategy | Use auto-detection (see below) or check `gh api repos/O/R --jq '{merge: .allow_merge_commit, squash: .allow_squash_merge, rebase: .allow_rebase_merge}'` |
 | "Rebase merges cannot be automatically signed" | Signed commits + rebase | Enable squash merge on the repo; rebase merges cannot be auto-signed by GitHub |
 | Bot detection misses reruns | `github.actor` changes on synchronize | Use `github.event.pull_request.user.login` instead of `github.actor` |
-| Secret scanning fails on bot PRs | Legacy `gitleaks-action@v2` needs a license secret Dependabot cannot read | Call `netresearch/.github/.github/workflows/gitleaks.yml@main` (betterleaks, no license); tune `.gitleaks.toml` for false positives |
+| Third-party gitleaks scan fails on bot PRs | Legacy `gitleaks-action@v2` needs a license secret Dependabot cannot read | Call `netresearch/.github/.github/workflows/gitleaks.yml@main` (betterleaks, no license); tune `.gitleaks.toml` for false positives |
 | Old PRs not auto-merging | Opened before workflow existed | Comment `@dependabot rebase` / `@renovate rebase` to trigger `synchronize` |
 | Can't merge workflow file PRs | `GITHUB_TOKEN` lacks `workflows` scope | Merge manually; use workflow check in `auto-merge-direct.yml` template |
 | Auto-approve skipped, PR stuck `REVIEW_REQUIRED` or blank `reviewDecision` | Auto-approve raced with Copilot reviewer | Re-run the auto-approve workflow after Copilot finishes; long-term fix is adding `pull_request_review` trigger — see [Auto-Approve Race Condition with Copilot Reviewer](#auto-approve-race-condition-with-copilot-reviewer) |

--- a/skills/github-project/references/auto-merge-guide.md
+++ b/skills/github-project/references/auto-merge-guide.md
@@ -47,7 +47,7 @@ EOF
 | "Merge method X not allowed" | Wrong merge strategy | Use auto-detection (see below) or check `gh api repos/O/R --jq '{merge: .allow_merge_commit, squash: .allow_squash_merge, rebase: .allow_rebase_merge}'` |
 | "Rebase merges cannot be automatically signed" | Signed commits + rebase | Enable squash merge on the repo; rebase merges cannot be auto-signed by GitHub |
 | Bot detection misses reruns | `github.actor` changes on synchronize | Use `github.event.pull_request.user.login` instead of `github.actor` |
-| Gitleaks fails on bot PRs | `GITLEAKS_LICENSE` secret unavailable | Skip gitleaks for bot PRs or use `.gitleaks.toml` allowlist |
+| Secret scanning fails on bot PRs | Legacy `gitleaks-action@v2` needs a license secret Dependabot cannot read | Call `netresearch/.github/.github/workflows/gitleaks.yml@main` (betterleaks, no license); tune `.gitleaks.toml` for false positives |
 | Old PRs not auto-merging | Opened before workflow existed | Comment `@dependabot rebase` / `@renovate rebase` to trigger `synchronize` |
 | Can't merge workflow file PRs | `GITHUB_TOKEN` lacks `workflows` scope | Merge manually; use workflow check in `auto-merge-direct.yml` template |
 | Auto-approve skipped, PR stuck `REVIEW_REQUIRED` or blank `reviewDecision` | Auto-approve raced with Copilot reviewer | Re-run the auto-approve workflow after Copilot finishes; long-term fix is adding `pull_request_review` trigger — see [Auto-Approve Race Condition with Copilot Reviewer](#auto-approve-race-condition-with-copilot-reviewer) |

--- a/skills/github-project/references/dependency-management.md
+++ b/skills/github-project/references/dependency-management.md
@@ -562,13 +562,13 @@ if: github.actor == 'dependabot[bot]'
 if: github.event.pull_request.user.login == 'dependabot[bot]'
 ```
 
-### Secret Scanning Fails on Dependabot/Renovate PRs
+### The gitleaks Action Fails on Dependabot/Renovate PRs
 
 **Error:** `gitleaks-action@v2` fails with a license error on bot PRs.
 
 **Cause:** `gitleaks-action@v2` requires a `GITLEAKS_LICENSE` secret for organization repositories, and Dependabot runs with restricted secret access — it can only read secrets prefixed with `DEPENDABOT_`. So the scan cannot be licensed on exactly the PRs that need it.
 
-**Solution:** Call the org reusable, which runs betterleaks. It is OSS, needs no license, and therefore has no bot-PR failure mode — no secret is passed to it at all:
+**Solution:** Call the org reusable, which runs betterleaks. (This is the third-party scan in your workflow, not GitHub's own secret scanning, which is configured per repository and unaffected.) It is OSS, needs no license, and therefore has no bot-PR failure mode — no secret is passed to it at all:
 ```yaml
 jobs:
   gitleaks:

--- a/skills/github-project/references/dependency-management.md
+++ b/skills/github-project/references/dependency-management.md
@@ -562,24 +562,20 @@ if: github.actor == 'dependabot[bot]'
 if: github.event.pull_request.user.login == 'dependabot[bot]'
 ```
 
-### Gitleaks Fails on Dependabot/Renovate PRs
+### Secret Scanning Fails on Dependabot/Renovate PRs
 
-**Error:** `gitleaks-action` fails with license error on bot PRs.
+**Error:** `gitleaks-action@v2` fails with a license error on bot PRs.
 
-**Cause:** `gitleaks-action@v2` requires a `GITLEAKS_LICENSE` secret, but Dependabot runs with restricted secret access — it can only access secrets prefixed with `DEPENDABOT_`.
+**Cause:** `gitleaks-action@v2` requires a `GITLEAKS_LICENSE` secret for organization repositories, and Dependabot runs with restricted secret access — it can only read secrets prefixed with `DEPENDABOT_`. So the scan cannot be licensed on exactly the PRs that need it.
 
-**Solution:** Skip gitleaks on bot PRs or use the free mode:
+**Solution:** Call the org reusable, which runs betterleaks. It is OSS, needs no license, and therefore has no bot-PR failure mode — no secret is passed to it at all:
 ```yaml
-- name: Gitleaks
-  uses: gitleaks/gitleaks-action@v2
-  # Skip on bot PRs where GITLEAKS_LICENSE is unavailable
-  if: github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.user.login != 'renovate[bot]'
-  env:
-    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
+jobs:
+  gitleaks:
+    uses: netresearch/.github/.github/workflows/gitleaks.yml@main
 ```
 
-Or add a `.gitleaks.toml` allowlist for known false positives.
+Do not skip the scan for bot PRs: a dependency update can carry a secret like any other change. For known false positives, add a `.gitleaks.toml` allowlist — the repo's own file is honoured, so tune it there rather than disabling the job.
 
 ### Pre-existing PRs Don't Auto-merge
 


### PR DESCRIPTION
Two passages still described the legacy setup: `dependency-management.md` had a troubleshooting section whose solution block wires `GITLEAKS_LICENSE` into `gitleaks/gitleaks-action@v2` and skips the scan for Dependabot and Renovate PRs, and `auto-merge-guide.md` carried a matching table row.

The org runs betterleaks via `netresearch/.github/.github/workflows/gitleaks.yml`. It is OSS, takes no license, and no secret is passed to it — so the failure mode the section works around does not exist for the recommended setup. The deprecated `GITLEAKS_LICENSE` input is being removed from the reusables in [netresearch/.github#337](https://github.com/netresearch/.github/pull/337), which would leave this guidance describing a secret that no longer has a declaration anywhere.

The advice to skip the scan on bot PRs is dropped rather than reworded: a dependency update can introduce a secret like any other change, and the `.gitleaks.toml` allowlist is the right lever for false positives.