### PR TITLE
docs(auto-merge): stability-days keeps an armed Renovate PR UNSTABLE on purpose

### DIFF
--- a/skills/github-project/references/auto-merge-guide.md
+++ b/skills/github-project/references/auto-merge-guide.md
@@ -503,7 +503,7 @@ confusing half-state.
 - `platformAutomerge: true` - Renovate enables auto-merge (uses bypass permissions)
 - `lockFileMaintenance` - Handles lock file updates via PR (not direct push)
 
-**`stability-days` / `minimumReleaseAge` keeps an armed PR `UNSTABLE` on purpose.** A Renovate PR with auto-merge armed, every real check green, and only `renovate/stability-days` PENDING is not stuck — the pending status *is* the supply-chain delay, and Renovate completes the merge when the window elapses. `mergeStateStatus` shows `UNSTABLE` the whole time. Leave it alone; merging by hand defeats the deliberate release-age gate.
+**The `renovate/stability-days` check (produced by the `minimumReleaseAge` config option, formerly `stabilityDays`) keeps an armed PR `UNSTABLE` on purpose.** A Renovate PR with auto-merge armed, every real check green, and only `renovate/stability-days` PENDING is not stuck — the pending status *is* the supply-chain delay, and Renovate completes the merge when the window elapses. `mergeStateStatus` shows `UNSTABLE` the whole time. Leave it alone; merging by hand defeats the deliberate release-age gate.
 
 ## Canonical Auto-merge Workflow Template
 

--- a/skills/github-project/references/auto-merge-guide.md
+++ b/skills/github-project/references/auto-merge-guide.md
@@ -503,6 +503,8 @@ confusing half-state.
 - `platformAutomerge: true` - Renovate enables auto-merge (uses bypass permissions)
 - `lockFileMaintenance` - Handles lock file updates via PR (not direct push)
 
+**`stability-days` / `minimumReleaseAge` keeps an armed PR `UNSTABLE` on purpose.** A Renovate PR with auto-merge armed, every real check green, and only `renovate/stability-days` PENDING is not stuck — the pending status *is* the supply-chain delay, and Renovate completes the merge when the window elapses. `mergeStateStatus` shows `UNSTABLE` the whole time. Leave it alone; merging by hand defeats the deliberate release-age gate.
+
 ## Canonical Auto-merge Workflow Template
 
 ```yaml


### PR DESCRIPTION
Documents that a Renovate PR with auto-merge armed and only renovate/stability-days PENDING is not stuck: the pending status is the supply-chain delay and Renovate merges when the window elapses; hand-merging defeats the release-age gate. Surfaced in the 2026-08-03 release sweep (pagerangers-skill#54).