### PR TITLE
docs(gh-cli): inline --body with backticks executes them — use --body-file

### DIFF
--- a/skills/github-project/references/gh-cli-reference.md
+++ b/skills/github-project/references/gh-cli-reference.md
@@ -130,11 +130,11 @@ gh pr close NUMBER --repo OWNER/REPO && sleep 2 && gh pr reopen NUMBER --repo OW
 
 ### Inline `--body` with Backticks EXECUTES Them — Always `--body-file`
 
-An inline body in double quotes — `gh pr create --body "..."` with a Markdown code span inside — makes bash run the span's backtick contents as **command substitution** before `gh` ever sees the text. In one real session this executed `bun audit`, `npm login`, and `npm publish` (only an ENEEDAUTH failure prevented an actual publish), and the resulting bodies were garbled with the substituted output. Any body containing Markdown code spans will misfire.
+An inline body in double quotes — `gh pr create --body "..."` with a Markdown code span inside — makes bash run the span's **unescaped** backtick contents as command substitution before `gh` ever sees the text (escaped backticks or a single-quoted body stay literal — but bodies are routinely assembled unescaped). In one real session this executed `bun audit`, `npm login`, and `npm publish` (only an ENEEDAUTH failure prevented an actual publish), and the resulting bodies were garbled with the substituted output. Any double-quoted body whose code spans are not escaped will misfire.
 
 ```bash
-# WRONG: backticks execute, $ expands
-gh pr create --body "Run \`npm test\` first"
+# WRONG: unescaped backticks execute npm test, $ expands
+gh pr create --body "Run `npm test` first"
 
 # RIGHT: quoted heredoc (no expansion) + --body-file
 cat > /tmp/body.md <<'EOF'

--- a/skills/github-project/references/gh-cli-reference.md
+++ b/skills/github-project/references/gh-cli-reference.md
@@ -128,6 +128,23 @@ When a fork's `main` is behind upstream and a PR is created after syncing, GitHu
 gh pr close NUMBER --repo OWNER/REPO && sleep 2 && gh pr reopen NUMBER --repo OWNER/REPO
 ```
 
+### Inline `--body` with Backticks EXECUTES Them — Always `--body-file`
+
+An inline body in double quotes — `gh pr create --body "..."` with a Markdown code span inside — makes bash run the span's backtick contents as **command substitution** before `gh` ever sees the text. In one real session this executed `bun audit`, `npm login`, and `npm publish` (only an ENEEDAUTH failure prevented an actual publish), and the resulting bodies were garbled with the substituted output. Any body containing Markdown code spans will misfire.
+
+```bash
+# WRONG: backticks execute, $ expands
+gh pr create --body "Run \`npm test\` first"
+
+# RIGHT: quoted heredoc (no expansion) + --body-file
+cat > /tmp/body.md <<'EOF'
+Run `npm test` first
+EOF
+gh pr create --body-file /tmp/body.md
+```
+
+Applies equally to `gh issue create/comment`, `gh release create --notes`, `gh pr comment`, and `git commit -m` with backticks (`-F file` there). Verify the posted body afterward (`gh pr view N --json body`) — garbling is silent.
+
 ### GraphQL with Special Characters (--input pattern)
 
 When GraphQL variables contain backticks, dollar signs, or other characters that cause bash escaping issues, pipe JSON via `--input -`:


### PR DESCRIPTION
## What

Adds the missing companion to "GraphQL with Special Characters": the plain-CLI variant. A double-quoted inline `--body` containing Markdown code spans undergoes **bash command substitution** — in one real session it executed `bun audit`, `npm login`, and `npm publish` (only ENEEDAUTH prevented an actual publish) and posted garbled bodies. Recipe: quoted heredoc → `--body-file`, verify the posted body afterward.

Promoted from session memory (`/retro promote`); the GraphQL-argument sibling note was already covered by the existing `--input -` section and is tombstoned without an upward write.

Came from /retro: yes
