### PR TITLE
docs: escape @-tokens in GitHub text; SonarCloud onboarding + Automatic Analysis gotchas

### DIFF
--- a/skills/github-project/references/gh-cli-reference.md
+++ b/skills/github-project/references/gh-cli-reference.md
@@ -81,7 +81,7 @@ In PR/issue **bodies and comments**, GitHub's renderer turns a single newline in
 
 ### Escape every `@`-token — GitHub mentions are live
 
-Any raw `@something` in GitHub-rendered text (PR/issue bodies, comments, release notes, wiki, README) is parsed as a user mention and NOTIFIES that account — `@main` in a workflow-pinning discussion repeatedly pinged the real GitHub user named "main". Wrap every non-mention `@`-token in backticks (`` `@main` ``) or escape it (`\@main`) before posting; audit generated bodies for bare `@` before sending.
+Any raw `@something` in interactive GitHub surfaces (PR/issue/discussion bodies and comments, release notes) is parsed as a user mention and — when it resolves to an existing user or team — can notify that account — `@main` in a workflow-pinning discussion repeatedly pinged the real GitHub user named "main". Repository docs (README, wiki) render the link but generally do not notify. Wrap every non-mention `@`-token in backticks (`` `@main` ``) or escape it (`\@main`) before posting; audit generated bodies for bare `@` before sending.
 
 ### Add an image to an issue or PR (no browser needed)
 

--- a/skills/github-project/references/gh-cli-reference.md
+++ b/skills/github-project/references/gh-cli-reference.md
@@ -79,6 +79,10 @@ Set `PYTHONUNBUFFERED: 1` in the step's `env:` (or run `python -u`) when you nee
 
 In PR/issue **bodies and comments**, GitHub's renderer turns a single newline into a hard line break (`<br>`) — it enables hard line breaks for issue/PR/comment text, unlike the CommonMark default (where a single newline is a soft break and an intentional break needs two trailing spaces, a trailing `\`, or an explicit `<br>`). So a prose paragraph hard-wrapped at ~80 columns renders as jagged, mid-sentence lines. Write each prose paragraph as one continuous line and separate paragraphs with a blank line; keep line breaks only where the break is the content (inside fenced code blocks, one item per line in a list). Source files behave the other way — reStructuredText and CommonMark `.md` render a single newline as a *soft* break, and a commit-message body is plain text, so all three are conventionally wrapped at ~72–80 columns and the wrap never shows. The rule follows how the destination treats a single newline, not whether the text is Markdown. When generating a body with `gh pr create --body-file` / `gh issue create --body-file`, do not pipe it through a hard-wrapper.
 
+### Escape every `@`-token — GitHub mentions are live
+
+Any raw `@something` in GitHub-rendered text (PR/issue bodies, comments, release notes, wiki, README) is parsed as a user mention and NOTIFIES that account — `@main` in a workflow-pinning discussion repeatedly pinged the real GitHub user named "main". Wrap every non-mention `@`-token in backticks (`` `@main` ``) or escape it (`\@main`) before posting; audit generated bodies for bare `@` before sending.
+
 ### Add an image to an issue or PR (no browser needed)
 
 GitHub's native attachment uploader (`user-attachments/assets/…`) needs a browser session + CSRF and cannot be driven by `gh`/the API — but that does **not** mean images are impossible. Commit the PNGs to a dedicated branch (in a fork if you lack push to the target), then embed the raw URL in the body/comment:

--- a/skills/github-project/references/merge-strategy.md
+++ b/skills/github-project/references/merge-strategy.md
@@ -318,6 +318,12 @@ The usual real causes: a required check still pending (see "`mergeStateStatus: B
 
 SonarCloud measures "new code" as lines touched by the PR, so mechanical refactors (e.g. method extraction, literal→const swaps) re-attribute pre-existing duplication and uncovered lines to the PR, failing `new_duplicated_lines_density` or `codecov/patch`. Don't resort to test-theater or risky out-of-scope de-duplication inside a behavior-preserving PR. First fix what is genuinely cheap and meaningful (a small unit test for an extracted helper often flips `codecov/project` green). For the structural residue, confirm the gate is **non-required** (`mergeStateStatus: UNSTABLE`, not `BLOCKED`), write a "Quality gate note" section into the PR body naming the metric, the cause, and why it is out of scope, then merge. Style-rule whack-a-mole (each push surfacing the next batch) is best handled by modernizing the whole file in one pass — but verify bulk codemods with the language's own parser (a naive `var`→`const` regex turns `var x;` into invalid `const x;`).
 
+
+### SonarCloud operational gotchas (onboarding + Automatic Analysis)
+
+- **The project's "Main Branch" slot defaults to `master`** regardless of the GitHub default branch, so first scans of a `main`-repo land on a short-lived branch literally named `main` and the overview claims "master branch has not been analyzed yet". Fix in Project → Administration → Branches: delete the short-lived `main` first (else the rename fails with "name already exists"), rename the Main Branch to `main`, trigger a fresh scan.
+- **Automatic Analysis (GitHub-App mode) silently ignores `sonar-project.properties`.** The file it honors is **`.sonarcloud.properties`** at repo root (Java-properties syntax), on the analyzed branch; it overrides UI Analysis-Scope settings. For false-positive sensors on template files (e.g. TYPO3 Fluid tripping the HTML sensor), plain `sonar.exclusions=...` removes the files from scope and cannot break analysis — prefer it over disabling sensors or `sonar.issue.ignore.multicriteria`.
+
 ### "Merge commits are not allowed on this repository"
 
 **Cause:** `allow_merge_commit` is false in repository settings.


### PR DESCRIPTION
## What

Three promoted learnings (`/retro promote`, batch 4):

- **`gh-cli-reference.md`**: every raw `@`-token in GitHub-rendered text is a live mention — `` `@main` `` unescaped in release notes/PR bodies repeatedly notified the real GitHub user named "main". Backtick-wrap or escape, and audit generated bodies before posting.
- **`merge-strategy.md`** (new "SonarCloud operational gotchas" subsection): the project's Main Branch slot defaults to `master` regardless of the GitHub default branch, stranding first scans on a short-lived `main` (fix sequence documented, incl. the delete-before-rename trap); Automatic Analysis silently ignores `sonar-project.properties` and honors only `.sonarcloud.properties`, where plain `sonar.exclusions` is the safe remedy for sensor false positives on template files.

Came from /retro: yes
