### PR TITLE
docs: all PR checks are required, audit-ignore mirroring for unbumpable CVEs, pnpm-before-setup-node

### DIFF
--- a/skills/github-project/references/dependency-management.md
+++ b/skills/github-project/references/dependency-management.md
@@ -680,3 +680,11 @@ gh api 'repos/OWNER/REPO/tags?per_page=1' --jq '.[0] | "\(.name) \(.commit.sha)"
 ```
 
 Verify the SHA is valid AND that it is the latest version (a valid SHA of an old tag passes review while staying outdated), then update ALL occurrences across `.github/workflows/*.yml`, not just the failing one.
+
+## `composer audit` flags a transitive CVE nothing can bump — mirror the audit-ignore
+
+A transitive package can be pinned below its fixed version by a direct dependency you don't control (e.g. `firebase/php-jwt < 7` held back by an OAuth lib's constraint, which is itself pinned by a wrapper library). No `composer update` in the app repo can fix that. The default branch usually already tolerates the CVE via `config.audit.ignore` in `composer.json` — mirror the identical entry onto the diverging branch: JSON-only, lock untouched, no behaviour change. Verify with the exact CI command (`composer audit --locked …` → exit 0, advisory listed as "ignored"). The real fix — releasing the pinning library with a loosened constraint — is a separate effort; don't block the immediate green on it.
+
+## `pnpm/action-setup` must run BEFORE `actions/setup-node` with `cache: "pnpm"`
+
+`actions/setup-node` with pnpm caching resolves the pnpm executable at setup time — if `pnpm/action-setup` hasn't run yet, it fails with `Unable to locate executable: pnpm`. Order the steps pnpm-first in any workflow using both.

--- a/skills/github-project/references/dependency-management.md
+++ b/skills/github-project/references/dependency-management.md
@@ -683,7 +683,7 @@ Verify the SHA is valid AND that it is the latest version (a valid SHA of an old
 
 ## `composer audit` flags a transitive CVE nothing can bump — mirror the audit-ignore
 
-A transitive package can be pinned below its fixed version by a direct dependency you don't control (e.g. `firebase/php-jwt < 7` held back by an OAuth lib's constraint, which is itself pinned by a wrapper library). No `composer update` in the app repo can fix that. The default branch usually already tolerates the CVE via `config.audit.ignore` in `composer.json` — mirror the identical entry onto the diverging branch: JSON-only, lock untouched, no behaviour change. Verify with the exact CI command (`composer audit --locked …` → exit 0, advisory listed as "ignored"). The real fix — releasing the pinning library with a loosened constraint — is a separate effort; don't block the immediate green on it.
+A transitive package can be pinned below its fixed version by a direct dependency you don't control (e.g. `firebase/php-jwt < 7` held back by an OAuth lib's constraint, which is itself pinned by a wrapper library). No `composer update` in the app repo can fix that. The default branch usually already tolerates the CVE via `config.audit.ignore` in `composer.json` — mirror the identical entry onto the diverging branch: JSON-only, lock untouched, no behavior change. Verify with the exact CI command (`composer audit --locked …` → exit 0, advisory listed as "ignored"). The real fix — releasing the pinning library with a loosened constraint — is a separate effort; don't block the immediate green on it.
 
 ## `pnpm/action-setup` must run BEFORE `actions/setup-node` with `cache: "pnpm"`
 

--- a/skills/github-project/references/merge-strategy.md
+++ b/skills/github-project/references/merge-strategy.md
@@ -378,7 +378,7 @@ fi
 
 ### Renaming a CI job orphans its required status check → PR stuck "Expected"
 
-**Every CI step that runs on a PR belongs in `required_status_checks` — advisory checks are decorative.** If a job's result would not stop a merge, the job's existence is theatre; a "flaky" or "in flux" check gets fixed or removed, not demoted to advisory. When adding a new CI job, add its context name to the ruleset in the same change; when a future shape change (sharding, matrix expansion) will rename the contexts, edit the ruleset twice — once now to lock the current shape, once at the change — rather than deferring the lock.
+**Every CI step that runs on a PR belongs in `required_status_checks` — advisory checks are decorative.** If a job's result would not stop a merge, the job provides no protection; a "flaky" or "in flux" check gets fixed or removed, not demoted to advisory. When adding a new CI job, add its context name to the ruleset in the same change; when a future shape change (sharding, matrix expansion) will rename the contexts, edit the ruleset twice — once now to lock the current shape, once at the change — rather than deferring the lock.
 
 Required status checks are matched by **exact context name**. Renaming a job — including changing a **matrix value** that appears in the job name (e.g. `PHPStan (8.2, ^14.0)` → `PHPStan (8.2, ^14.3)`) — produces a *new* context name. The old required context no longer reports, so it sits "Expected — Waiting for status to be reported" forever and the PR is `BLOCKED`, even though every job is green.
 

--- a/skills/github-project/references/merge-strategy.md
+++ b/skills/github-project/references/merge-strategy.md
@@ -378,6 +378,8 @@ fi
 
 ### Renaming a CI job orphans its required status check → PR stuck "Expected"
 
+**Every CI step that runs on a PR belongs in `required_status_checks` — advisory checks are decorative.** If a job's result would not stop a merge, the job's existence is theatre; a "flaky" or "in flux" check gets fixed or removed, not demoted to advisory. When adding a new CI job, add its context name to the ruleset in the same change; when a future shape change (sharding, matrix expansion) will rename the contexts, edit the ruleset twice — once now to lock the current shape, once at the change — rather than deferring the lock.
+
 Required status checks are matched by **exact context name**. Renaming a job — including changing a **matrix value** that appears in the job name (e.g. `PHPStan (8.2, ^14.0)` → `PHPStan (8.2, ^14.3)`) — produces a *new* context name. The old required context no longer reports, so it sits "Expected — Waiting for status to be reported" forever and the PR is `BLOCKED`, even though every job is green.
 
 This is a silent trap: the CI change looks self-contained, but the required-checks list in branch protection / the ruleset still names the old job. Treat the required-checks list as a declared value that must be swept whenever a job name changes.


### PR DESCRIPTION
## What

Three promoted learnings (`/retro promote`, batch 6):

- **`merge-strategy.md`**: every CI step that runs on a PR belongs in `required_status_checks` — an advisory check is decorative; lock the context in the same change that adds the job, and on shape changes edit the ruleset twice rather than deferring the lock. (Explicit user policy across the TYPO3 extension repos.)
- **`dependency-management.md`**: when `composer audit` flags a transitive CVE that a third-party pin makes unbumpable, mirror the default branch's `config.audit.ignore` entry (JSON-only, lock untouched) and verify with the exact CI audit command — the real fix (releasing the pinning library) is a separate effort.
- **`dependency-management.md`**: `pnpm/action-setup` must precede `actions/setup-node` with `cache: "pnpm"` (`Unable to locate executable: pnpm` otherwise).

Came from /retro: yes
