### PR TITLE
chore(release): v2.15.14

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "github-project",
-  "version": "2.15.13",
+  "version": "2.15.14",
   "description": "GitHub repository setup, branch protection, and configuration",
   "repository": "https://github.com/netresearch/github-project-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",

--- a/skills/github-project/SKILL.md
+++ b/skills/github-project/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires gh CLI, git."
 metadata:
   author: Netresearch DTT GmbH
-  version: "2.15.13"
+  version: "2.15.14"
   repository: https://github.com/netresearch/github-project-skill
 allowed-tools: Bash(gh:*) Bash(git:*) Bash(grep:*) Read Write
 ---


### PR DESCRIPTION
Version bump 2.15.13 → 2.15.14.

Changes since v2.15.13:

- docs(auto-merge): stability-days keeps an armed Renovate PR UNSTABLE on purpose
- docs(auto-merge): use the full renovate/stability-days check name
- docs(merge-strategy): BLOCKED with all checks green — list check-suites
- docs(merge-strategy): correct the check-runs claim — in-progress runs do appear; the blind spot is a suite with no runs yet
- docs(gh-cli): inline --body with backticks executes them — use --body-file
- docs(gh-cli): the trap is unescaped backticks — fix the WRONG example accordingly
- docs(repo-structure): RST admonitions render as bare !DANGER! text on GitHub
- docs(repo-structure): generalize the doubled-hr caveat per review
- docs: escape @-tokens in GitHub text; SonarCloud onboarding + Automatic Analysis gotchas
- docs(gh-cli): scope the mention warning to interactive surfaces, soften to can-notify
- docs: push-protection fixtures, cross-repo release CI race, Automatic Analysis honor list
- docs(deps): spell out the two dependent-PR actions per review
- docs(deps): dependabot dismissal comment cap, workflow-file bot PRs via SSH, actions-version lookup
- docs(deps): dedupe workflow-file section against existing GITHUB_TOKEN guidance; per_page=1 on tags lookup
- docs: all PR checks are required, audit-ignore mirroring for unbumpable CVEs, pnpm-before-setup-node
- docs: neutral wording and consistent spelling per review
- docs(gh-cli): review requests can evaporate — verify and re-request; merged is not a pr-view field
- docs: reusable-workflow ops bundle; GHCR multi-arch cleanup brick; API commits are unsigned

Surfaces bumped: `.claude-plugin/plugin.json`, SKILL.md frontmatter version.
