### PR TITLE
docs(repo-bootstrap): describe fork-PR approval from the contributor side

### DIFF
--- a/skills/github-project/references/repo-bootstrap.md
+++ b/skills/github-project/references/repo-bootstrap.md
@@ -133,6 +133,16 @@ gh api repos/OWNER/REPO/actions/permissions/fork-pr-contributor-approval -X PUT 
 | `first_time_contributors` | First-time contributors to this repo |
 | `all_external_contributors` | Every external contributor (safest) |
 
+**From the contributor side, this looks like a broken PR.** Every workflow reports `action_required` — `completed/action_required`, not `failure` — and `gh pr checks` shows only the handful of jobs that run without approval (`pull_request_target` ones, e.g. a PR-title linter). Nothing is wrong and there is nothing to fix; a maintainer has to click *Approve and run workflows*. Confirm rather than guess:
+
+```bash
+gh api "repos/OWNER/REPO/actions/runs?event=pull_request" \
+  --jq '.workflow_runs[] | select(.head_branch=="MY-BRANCH")
+        | "\(.name): \(.status)/\(.conclusion)"'
+```
+
+A uniform `completed/action_required` across every workflow is the approval gate, not a red build. Do not push "fix CI" commits at it.
+
 ### Security toggles
 
 ```bash


### PR DESCRIPTION
## Summary

Documents what the existing fork-PR approval setting looks like from the contributor's side, so a held PR is not mistaken for a red build.

## Came from

`/retro` session on 2026-08-07: `3b2909e2-2cc1-4876-a6d4-76ec690cc48d`
Finding: A6/B13 — context that had to be re-derived mid-session.

- **Symptom:** A first-contribution fork PR showed ten workflows at `completed/action_required` and `gh pr checks` listed a single passing job. It read as broken CI, and establishing that it was not cost a round.
- **Cause:** The "Fork-PR approval" section documents the maintainer endpoint and its policy values but not the contributor-visible symptom. `action_required` is a *conclusion*, not a failure, and `gh pr checks` shows only the `pull_request_target` jobs that run without approval — so the checks list looks nearly empty rather than red, which is easy to misread in either direction.
- **Required behavior:** Recognise a uniform `completed/action_required` across every workflow as the approval gate. Confirm it with the runs API rather than guessing, and do not push "fix CI" commits at a gate waiting on a human.
- **Verification:** No `evals/` entry added — documentation change. The query in the change is the one that resolved it in-session.

## Change

`references/repo-bootstrap.md` — a paragraph after the `approval_policy` table giving the contributor-side symptom, the `gh api repos/OWNER/REPO/actions/runs?event=pull_request` query filtered to the branch, and the warning against pushing at it.

`SKILL.md` untouched (499 words, already at the cap).

## Test plan

- [ ] The `gh api` query returns `name: status/conclusion` lines for a fork PR
- [ ] Wording distinguishes `action_required` from `failure` clearly enough to act on
- [ ] `SKILL.md` still 499 words

## Note on scope

The finding this came from also covered running an upstream repo's `CONTRIBUTING.md` gate before opening a PR. That half went to `git-workflow` (netresearch/git-workflow-skill#148), which owns PR creation; this repo keeps the fork/CI half. Splitting it also avoided adding an orphan reference file here, since `SKILL.md` is at the 500-word cap and every reference must be linked from it.
