### PR TITLE
chore(release): v2.16.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "github-project",
-  "version": "2.15.14",
+  "version": "2.16.0",
   "description": "GitHub repository setup, branch protection, and configuration",
   "author": {
     "name": "Netresearch DTT GmbH",

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "github-project",
-  "version": "2.15.14",
+  "version": "2.16.0",
   "description": "GitHub repository setup, branch protection, and configuration",
   "author": {
     "name": "Netresearch DTT GmbH",

--- a/skills/github-project/SKILL.md
+++ b/skills/github-project/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires gh CLI, git."
 metadata:
   author: Netresearch DTT GmbH
-  version: "2.15.14"
+  version: "2.16.0"
   repository: https://github.com/netresearch/github-project-skill
 allowed-tools: Bash(gh:*) Bash(git:*) Bash(grep:*) Read Write
 ---


### PR DESCRIPTION
Release v2.16.0.

Version bump only.

Bumped: root `plugin.json`, `.claude-plugin/plugin.json`, every `skills/*/SKILL.md` frontmatter version. Parity verified with `check-version-parity.sh v2.16.0`.

Tag `v2.16.0` follows once this merges.