### PR TITLE
chore(release): v2.16.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "github-project",
-  "version": "2.16.0",
+  "version": "2.16.1",
   "description": "GitHub repository setup, branch protection, and configuration",
   "author": {
     "name": "Netresearch DTT GmbH",

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "github-project",
-  "version": "2.16.0",
+  "version": "2.16.1",
   "description": "GitHub repository setup, branch protection, and configuration",
   "author": {
     "name": "Netresearch DTT GmbH",

--- a/skills/github-project/SKILL.md
+++ b/skills/github-project/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires gh CLI, git."
 metadata:
   author: Netresearch DTT GmbH
-  version: "2.16.0"
+  version: "2.16.1"
   repository: https://github.com/netresearch/github-project-skill
 allowed-tools: Bash(gh:*) Bash(git:*) Bash(grep:*) Read Write
 ---


### PR DESCRIPTION
Version bump to 2.16.1 for release: rolls the changelog where present and updates every version surface. No content changes beyond the release metadata.