### PR TITLE
docs(multi-repo): probing paths cannot tell absent from unlooked-at

### DIFF
--- a/skills/github-project/references/multi-repo-operations.md
+++ b/skills/github-project/references/multi-repo-operations.md
@@ -248,6 +248,37 @@ declaration other repos depend on), enumerate structurally instead: probe each
 repo for the marker file with `gh api repos/OWNER/REPO/contents/<path>`, which
 reads the live tree rather than an index.
 
+### Probing paths answers a narrower question than it looks
+
+The `contents/<path>` probe above is right about the index, but it only ever
+answers *is the file at this path*. A sweep built from a list of plausible paths
+reports the same "absent" for a file that does not exist and for one that sits
+somewhere the list does not name — and the resulting count reads like a
+measurement.
+
+Measured across 25 extensions: a sweep of five plausible `php-cs-fixer` config
+paths reported 11 repositories with no config. Ten of them had one, at a sixth
+path that was the single most common layout in that fleet. The real figure for
+the defect being tracked was 13 repositories, not 3, and the number had already
+reached an issue and a colleague. Worse, the fix under review had been built
+from the same guessed list, so it repaired the flag and left ten repositories
+exactly as broken as before.
+
+A candidate list is assembled from the layouts you already know. The layouts you
+do not know are the reason the sweep exists. So list the tree and classify what
+comes back:
+
+```bash
+# Every matching path, whatever the layout — one request per repo
+gh api "repos/OWNER/REPO/git/trees/BRANCH?recursive=1" \
+  --jq '[.tree[] | select(.path|test("php-cs-fixer";"i"))
+        | select(.path|test("^vendor/|^\\.Build/")|not) | .path] | join(" ")'
+```
+
+Where probing is genuinely the only option, do not name the empty bucket
+"absent". Call it "none of the paths checked" and print which ones were checked,
+so the next reader can see the hole instead of inheriting the number.
+
 ## Cache-Safety for Batch Operations
 
 When iterating across many local worktrees, it's easy to edit an installed skill/plugin cache by mistake. Before any write in a multi-repo loop:


### PR DESCRIPTION
`multi-repo-operations.md` recommends probing each repository with `contents/<path>` when a content search cannot be trusted. That advice is sound against the search index, and it has a blind spot worth naming: the probe answers *is the file at this path*, never *does the file exist*. A sweep assembled from plausible paths therefore reports the same "absent" for a file that is not there and one that sits at a path nobody thought of — and the count that comes out reads like a measurement.

## The measurement behind it

Across the 25 active `t3x-*` extensions, a sweep of five plausible `php-cs-fixer` config paths reported 11 repositories with no config at all. Ten of them had one, at `Build/.php-cs-fixer.dist.php` — the sixth path, and the most common layout in that fleet.

| | reported | actual |
| --- | --- | --- |
| repositories affected by the defect being tracked | 3 | 13 |
| repositories with "no config" | 11 | 1 |

The wrong number had already reached an issue body and two messages to a colleague. The more expensive part: the fix under review had been built from the same guessed list, so it repaired the flag and left ten repositories exactly as broken as before — the guard passed, because the guard's fixtures were drawn from that list too.

## What the section adds

The tree listing as the alternative, and one rule for where probing is genuinely the only option: do not name the empty bucket "absent", name it "none of the paths checked" and print the list, so the next reader sees the hole rather than inheriting the number.

## Verification

The documented command was extracted from the rendered file and run as written against a repository with the awkward layout:

```
$ gh api "repos/netresearch/t3x-nr-image-sitemap/git/trees/main?recursive=1" --jq '…'
Build/.php-cs-fixer.dist.php
```

That is the path the five-candidate sweep missed.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01GSptxPLHWsttu9FuqVkvYZ)_
